### PR TITLE
chore: remove `continue-on-error` from HACS validation

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -88,7 +88,6 @@ jobs:
       uses: hacs/action@main
       with:
         category: integration
-      continue-on-error: true
 
   hassfest:
     runs-on: ubuntu-latest

--- a/.github/workflows/manual-validation.yml
+++ b/.github/workflows/manual-validation.yml
@@ -113,4 +113,3 @@ jobs:
       uses: hacs/action@main
       with:
         category: integration
-      continue-on-error: true


### PR DESCRIPTION
Remove `continue-on-error: true` from the HACS validation step in both `ci.yml` and `manual-validation.yml`. This change ensures that any failures during HACS validation will prevent the workflow from proceeding, thus highlighting issues early and maintaining stricter data integrity during continuous integration and manual validation processes.