### PR TITLE
fix: rename domain constant

### DIFF
--- a/custom_components/custom_areas/const.py
+++ b/custom_components/custom_areas/const.py
@@ -1,6 +1,6 @@
 """Constants for the Custom Areas Integration."""
 
-DOMAIN = "areas"
+DOMAIN = "custom_areas"
 CONF_AREA_NAME = "area_name"
 CONF_POWER_ENTITY = "power_entity"
 CONF_ENERGY_ENTITY = "energy_entity"


### PR DESCRIPTION
Change the DOMAIN constant from "areas" to "custom_areas" to provide more clarity and consistency with the integration name.