### PR TITLE
Potential fix for code scanning alert no. 14: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -1,5 +1,8 @@
 name: Pre-commit
 
+permissions:
+  contents: read
+
 on:
   pull_request:
   push:


### PR DESCRIPTION
Potential fix for [https://github.com/DefinitelyADev/custom-areas-integration/security/code-scanning/14](https://github.com/DefinitelyADev/custom-areas-integration/security/code-scanning/14)

To fix this problem, we need to explicitly add a `permissions` block to the workflow YAML file. The best way is to add this at the root level (before `jobs:`), which will apply to all jobs unless a job defines more specific permissions. For this workflow, the steps involve checking out code and running pre-commit hooks, which only require `contents: read` permissions for the GITHUB_TOKEN (unless the workflow is writing to issues, pull requests, etc., which is not shown here). Therefore, set the permissions root block as:

```yaml
permissions:
  contents: read
```

This change should be made to `.github/workflows/pre-commit.yml` immediately after the workflow name and before the `on:` block.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
