### PR TITLE
fix: trigger workflow on all tags and update Codecov action file input

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,7 +38,7 @@ jobs:
       if: matrix.python-version == '3.11'
       uses: codecov/codecov-action@v5
       with:
-        file: ./coverage.xml
+        files: ./coverage.xml
         fail_ci_if_error: false
 
   validate:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,6 +6,7 @@ permissions:
 on:
   push:
     branches: [ master, main ]
+    tags: [ 'v[0-9][0-9]*.[0-9][0-9]*.[0-9][0-9]*', 'v[0-9][0-9]*.[0-9][0-9]*.[0-9][0-9]*-[0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f]' ]
   pull_request:
     branches: [ master, main ]
   workflow_dispatch:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 - Updated CI workflow tag patterns to restrict triggers to version tags matching `vX.X.X` or `vX.X.X-<short-commit-hash>`
+- Fixed Codecov action input to use 'files' instead of 'file'
 - Fixed workflow permissions to resolve code scanning alerts
 
 ## [1.2.0] - 2025-09-22

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,13 @@ All notable changes to the Rooms integration will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## ## [1.2.0] - TBD
+## [1.2.1] - 2025-09-22
+
+### Fixed
+- Updated CI workflow tag patterns to restrict triggers to version tags matching `vX.X.X` or `vX.X.X-<short-commit-hash>`
+- Fixed workflow permissions to resolve code scanning alerts
+
+## [1.2.0] - 2025-09-22
 
 ### Added
 - Individual measurement sensors: `AreaPowerSensor`, `AreaEnergySensor`, `AreaTemperatureSensor`, `AreaHumiditySensor`, `AreaClimateTargetSensor`


### PR DESCRIPTION
This pull request focuses on improving the CI workflow configuration and updating documentation to reflect these changes. The main updates include refining which tags trigger the CI workflow, correcting a configuration option for the Codecov action, and updating the changelog.

**CI Workflow Improvements:**

* Updated the `ci.yml` workflow to only trigger on tags that match version patterns like `vX.X.X` or `vX.X.X-<short-commit-hash>`, reducing unnecessary workflow runs.
* Changed the Codecov action configuration from `file` to `files` to match the expected input and avoid potential errors.

**Documentation Updates:**

* Added a new entry in `CHANGELOG.md` for version `1.2.1`, documenting the CI workflow tag pattern update and a fix for workflow permissions.