### PR TITLE
Potential fix for code scanning alert no. 12: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/manual-validation.yml
+++ b/.github/workflows/manual-validation.yml
@@ -1,4 +1,6 @@
 name: Manual Validation
+permissions:
+  contents: read
 
 on:
   workflow_dispatch:


### PR DESCRIPTION
Potential fix for [https://github.com/DefinitelyADev/custom-areas-integration/security/code-scanning/12](https://github.com/DefinitelyADev/custom-areas-integration/security/code-scanning/12)

To fix this problem, we should explicitly specify the `permissions` block at the top level of the workflow file (`.github/workflows/manual-validation.yml`), just below the workflow `name` definition. For this particular workflow, all jobs just check out code, run validation, or run local checks, and none of the jobs require write access to PRs, issues, or repository contents. Therefore, only the minimal `contents: read` permission is required, which is sufficient for `actions/checkout` to operate. Add the following block after the `name: Manual Validation` line:

```yaml
permissions:
  contents: read
```

No changes to any other sections are required; do not modify any job-level configurations as all jobs operate with the minimum permission set. This change fully addresses CodeQL’s flagged issue for lack of explicit permissions.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
