### PR TITLE
chore: add stale workflow to manage inactive issues/PRs

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -1,0 +1,29 @@
+# This workflow warns and then closes issues and PRs that have had no activity for a specified amount of time.
+#
+# You can adjust the behavior by modifying this file.
+# For more information, see:
+# https://github.com/actions/stale
+name: Mark stale issues and pull requests
+
+on:
+  schedule:
+  - cron: '19 4 * * *'
+
+jobs:
+  stale:
+    permissions:
+      actions: write
+      issues: write
+      pull-requests: write
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/stale@v10
+      with:
+        stale-issue-message: 'This issue is stale because it has been open 30 days with no activity. Remove stale label or comment or this will be closed in 5 days.'
+        stale-pr-message: 'This PR is stale because it has been open 30 days with no activity. Remove stale label or comment or this will be closed in 5 days.'
+        close-issue-message: 'This issue was closed because it has been stalled for 5 days with no activity.'
+        close-pr-message: 'This PR was closed because it has been stalled for 5 days with no activity.'
+        days-before-stale: 30
+        days-before-close: 5
+        exempt-issue-labels: 'enhancement,bug'
+        exempt-pr-labels: 'enhancement,bug'


### PR DESCRIPTION
Add a GitHub Actions workflow, 'stale.yml', to automatically manage stale issues and pull requests. This workflow marks issues and PRs as stale after 30 days of inactivity and closes them if no action is taken within an additional 5 days. This change helps maintain repository hygiene by reducing the number of inactive issues and PRs. Exempt labels include 'enhancement' and 'bug'.