### PR TITLE
chore(deps): ignore dependabot bumps for phacc-pinned test deps

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,6 +4,13 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
+    # pytest, pytest-asyncio, and pytest-cov are pinned exactly by
+    # pytest-homeassistant-custom-component. Dependabot bumps of these break
+    # CI until phacc itself loosens. Let phacc drive these transitively.
+    ignore:
+      - dependency-name: "pytest"
+      - dependency-name: "pytest-asyncio"
+      - dependency-name: "pytest-cov"
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:


### PR DESCRIPTION
pytest, pytest-asyncio, and pytest-cov are pinned exactly by pytest-homeassistant-custom-component. Dependabot PRs bumping them past the phacc pin (e.g. pytest>=9.0.3 vs phacc's pytest==9.0.0) fail CI until phacc itself loosens. Let phacc drive these transitively.