### PR TITLE
Phase 1: restore dual-form attrs, fix icon docs, bump to 1.3.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,15 @@ All notable changes to the Rooms integration will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.3.0] - 2026-05-27
+
+### Fixed
+- Restored dual-form numeric attributes (`power_w`, `energy_wh`, `temperature_c`, `humidity_pct`, `climate_target_c`) on `AreaSummarySensor` — regression from v1.2.0 that broke the documented contract.
+- Documented default icon now matches code behavior (`mdi:texture-box`).
+
+### Removed
+- Unused `ICON_HOME` constant.
+
 ## [1.2.2] - 2025-09-22
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -116,7 +116,7 @@ The area state is determined by this priority:
 The summary sensor icon changes based on area status:
 - Window open: `mdi:window-open-variant`
 - Motion detected: `mdi:motion-sensor`
-- Default: `mdi:home`
+- Default: `mdi:texture-box`
 
 ## Device Registry
 

--- a/custom_components/custom_areas/const.py
+++ b/custom_components/custom_areas/const.py
@@ -20,6 +20,5 @@ DEFAULT_ICON = "mdi:texture-box"
 STATE_ACTIVE = "active"
 
 # Icons
-ICON_HOME = "mdi:home"
 ICON_MOTION = "mdi:motion-sensor"
 ICON_WINDOW_OPEN = "mdi:window-open-variant"

--- a/custom_components/custom_areas/manifest.json
+++ b/custom_components/custom_areas/manifest.json
@@ -9,5 +9,5 @@
   "iot_class": "local_push",
   "issue_tracker": "https://github.com/DefinitelyADev/room-entity/issues",
   "requirements": [],
-  "version": "1.2.0"
+  "version": "1.3.0"
 }

--- a/custom_components/custom_areas/sensor.py
+++ b/custom_components/custom_areas/sensor.py
@@ -309,13 +309,17 @@ class AreaSummarySensor(SensorEntity):
             if climate_state:
                 attrs["climate_mode"] = climate_state.state
 
-        # Measurement attributes
+        # Measurement attributes — ship both a numeric (`*_w`, `*_wh`, `*_c`, `*_pct`)
+        # and stringified-with-unit form per the documented contract (README.md,
+        # docs/api.md). Pair each numeric/string emission so the contract is
+        # grep-able from a single block.
         power_entity = data.get(CONF_POWER_ENTITY)
         if power_entity:
             power_value = get_numeric_state(self.hass, power_entity)
             if power_value is not None:
                 power_state = self.hass.states.get(power_entity)
                 unit = power_state.attributes.get("unit_of_measurement") if power_state else UNIT_WATT
+                attrs["power_w"] = power_value
                 attrs["power"] = f"{power_value} {unit}"
 
         energy_entity = data.get(CONF_ENERGY_ENTITY)
@@ -324,6 +328,7 @@ class AreaSummarySensor(SensorEntity):
             if energy_value is not None:
                 energy_state = self.hass.states.get(energy_entity)
                 unit = energy_state.attributes.get("unit_of_measurement") if energy_state else UNIT_WATT_HOUR
+                attrs["energy_wh"] = energy_value
                 attrs["energy"] = f"{energy_value} {unit}"
 
         temp_entity = data.get(CONF_TEMP_ENTITY)
@@ -332,6 +337,7 @@ class AreaSummarySensor(SensorEntity):
             if temp_value is not None:
                 temp_state = self.hass.states.get(temp_entity)
                 unit = temp_state.attributes.get("unit_of_measurement") if temp_state else UNIT_CELSIUS
+                attrs["temperature_c"] = temp_value
                 attrs["temperature"] = f"{temp_value} {unit}"
 
         humidity_entity = data.get(CONF_HUMIDITY_ENTITY)
@@ -340,6 +346,7 @@ class AreaSummarySensor(SensorEntity):
             if humidity_value is not None:
                 humidity_state = self.hass.states.get(humidity_entity)
                 unit = humidity_state.attributes.get("unit_of_measurement") if humidity_state else UNIT_HUMIDITY
+                attrs["humidity_pct"] = humidity_value
                 attrs["humidity"] = f"{humidity_value} {unit}"
 
         climate_entity = data.get(CONF_CLIMATE_ENTITY)
@@ -349,6 +356,7 @@ class AreaSummarySensor(SensorEntity):
                 try:
                     target_value = float(climate_state.attributes["temperature"])
                     unit = climate_state.attributes.get("unit_of_measurement") or UNIT_CELSIUS
+                    attrs["climate_target_c"] = target_value
                     attrs["climate_target"] = f"{target_value} {unit}"
                 except (ValueError, TypeError):
                     pass

--- a/custom_components/custom_areas/tests/test_sensor.py
+++ b/custom_components/custom_areas/tests/test_sensor.py
@@ -239,12 +239,18 @@ def test_area_summary_sensor_attributes(mock_coordinator, mock_config_entry, moc
     assert attrs["window_open"] is False
     assert attrs["climate_mode"] == "heat"
 
-    # Measurement attributes should now be present as strings with units
+    # Measurement attributes ship in both numeric and stringified-with-unit
+    # form per the documented contract (README.md, docs/api.md).
     assert attrs["power"] == "25.5 W"
+    assert attrs["power_w"] == 25.5
     assert attrs["energy"] == "150.0 Wh"
+    assert attrs["energy_wh"] == 150.0
     assert attrs["temperature"] == "22.3 °C"
+    assert attrs["temperature_c"] == 22.3
     assert attrs["humidity"] == "65.0 %"
+    assert attrs["humidity_pct"] == 65.0
     assert attrs["climate_target"] == "21.5 °C"
+    assert attrs["climate_target_c"] == 21.5
 
 
 def test_area_summary_sensor_icon(mock_coordinator, mock_config_entry, mock_hass):
@@ -280,33 +286,62 @@ def test_area_summary_sensor_icon(mock_coordinator, mock_config_entry, mock_hass
 
 
 def test_sensor_functionality_with_fallback_units(mock_coordinator, mock_config_entry, mock_hass):
-    """Test that summary sensor works correctly with simplified attributes."""
+    """Verify the documented dual-form contract on AreaSummarySensor.
+
+    Every numeric measurement ships as both a numeric attribute (e.g.
+    `power_w`) and a stringified-with-unit attribute (e.g. `power`).
+    See README.md and docs/api.md.
+    """
     sensor_instance = AreaSummarySensor(mock_coordinator, mock_config_entry)
     sensor_instance.hass = mock_hass
 
-    # Mock states - only binary sensors for summary sensor
     motion_state = MagicMock()
     motion_state.state = STATE_ON
+
+    power_state = MagicMock()
+    power_state.state = "42.0"
+    power_state.attributes = {"unit_of_measurement": "W"}
+
+    energy_state = MagicMock()
+    energy_state.state = "1000.0"
+    energy_state.attributes = {"unit_of_measurement": "Wh"}
+
+    temp_state = MagicMock()
+    temp_state.state = "20.0"
+    temp_state.attributes = {"unit_of_measurement": "°C"}
+
+    humidity_state = MagicMock()
+    humidity_state.state = "55.0"
+    humidity_state.attributes = {"unit_of_measurement": "%"}
 
     def mock_get(entity_id):
         if entity_id == "binary_sensor.motion":
             return motion_state
+        elif entity_id == "sensor.power":
+            return power_state
+        elif entity_id == "sensor.energy":
+            return energy_state
+        elif entity_id == "sensor.temperature":
+            return temp_state
+        elif entity_id == "sensor.humidity":
+            return humidity_state
         return None
 
     mock_hass.states.get = mock_get
 
-    # Test that only appropriate attributes are generated for summary sensor
     attrs = sensor_instance.extra_state_attributes
 
-    # Only binary sensor attributes should be present
+    # Binary sensor attribute
     assert attrs["occupied"] is True
 
-    # Numeric measurement attributes should no longer be in summary sensor
-    assert "power_w" not in attrs
-    assert "energy_wh" not in attrs
-    assert "temperature_c" not in attrs
+    # Numeric measurement attributes ARE present per the documented contract.
+    assert attrs["power_w"] == 42.0
+    assert attrs["energy_wh"] == 1000.0
+    assert attrs["temperature_c"] == 20.0
+    assert attrs["humidity_pct"] == 55.0
 
-    # Display attributes should no longer be in summary sensor
-    assert "power" not in attrs
-    assert "energy" not in attrs
-    assert "temperature" not in attrs
+    # Stringified-with-unit attributes are present alongside the numeric form.
+    assert attrs["power"] == "42.0 W"
+    assert attrs["energy"] == "1000.0 Wh"
+    assert attrs["temperature"] == "20.0 °C"
+    assert attrs["humidity"] == "55.0 %"

--- a/docs/api.md
+++ b/docs/api.md
@@ -90,4 +90,4 @@ The sensor icon changes based on room status:
 
 1. **Window Open**: If window sensor is ON → `mdi:window-open-variant`
 2. **Motion Detected**: If motion sensor is ON → `mdi:motion-sensor`
-3. **Default**: `mdi:home`
+3. **Default**: `mdi:texture-box`


### PR DESCRIPTION
## Summary

Restores the load-bearing `AreaSummarySensor` contract that broke in the v1.2.0 refactor, fixes the icon-default doc mismatch, and reconciles the version skew between `manifest.json`, `CHANGELOG.md`, and the `v1.3.0` tag.

- **C1** — Restored dual-form numeric attributes (`power_w`/`energy_wh`/`temperature_c`/`humidity_pct`/`climate_target_c`) on `AreaSummarySensor`. These are documented in README, docs/api.md, docs/rationale.md, AGENTS.md, CLAUDE.md, and the CHANGELOG, but had been removed (and tests updated to enshrine the removal) in commit `db47acb` (v1.2.0, Sep 2025). Purely additive — the existing stringified `power: "28.6 W"` form is unchanged.
- **C2** — README and docs/api.md said the default icon is `mdi:home`; code and tests have always used `mdi:texture-box`. Aligned docs to code. Deleted the unused `ICON_HOME` constant from `const.py`.
- **C3** — Bumped `manifest.json` from `1.2.0` to `1.3.0` (matches the already-published `v1.3.0` tag). Added `## [1.3.0] - 2026-05-27` entry to CHANGELOG.

## Commits

```
84d7a2f fix(C1): restore dual-form numeric attrs on AreaSummarySensor
f197d81 test(C1): assert dual-form attrs are present
96fe22c docs(C2): align default-icon docs with code (mdi:texture-box)
07dfc7a chore(C2): remove unused ICON_HOME constant
07b6d94 chore(C3): bump version to 1.3.0 and update CHANGELOG
```

## Test plan

- [ ] CI green (test matrix HA 2024/2025/2026, validate, type-check, lint, hacs-validation, hassfest)
- [ ] In an HA dev instance, configure an area with power/temperature/motion. Confirm the summary sensor's attributes include BOTH `power` (string with unit) AND `power_w` (numeric). Same for energy, temperature, humidity, climate_target.
- [ ] Confirm default icon renders as `mdi:texture-box` (no override; no window/motion active).
- [ ] HACS update offer reaches users on 1.2.0/1.2.1/1.2.2 (manifest version drives this).

## Stacking note

This is the foundation. **Merge this first.** Phases 2/3/4 are branched off this; Phase 5 is independent and can land in any order. See the plan file for the full remediation roadmap.

Generated with [Claude Code](https://claude.com/claude-code)