### PR TITLE
Phase 5: gate release on hassfest + manifest-vs-tag check

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -148,6 +148,16 @@ jobs:
     steps:
     - uses: actions/checkout@v6
 
+    - name: Verify manifest version matches tag
+      run: |
+        manifest_version=$(jq -r .version custom_components/custom_areas/manifest.json)
+        tag_version="${{ github.ref_name }}"
+        tag_version="${tag_version#v}"
+        if [ "$manifest_version" != "$tag_version" ]; then
+          echo "::error::manifest.json version ($manifest_version) does not match tag ($tag_version)"
+          exit 1
+        fi
+
     - name: Create Release
       uses: softprops/action-gh-release@v2
       with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -140,7 +140,7 @@ jobs:
       uses: home-assistant/actions/hassfest@master
 
   release:
-    needs: [test, validate, type-check, lint, hacs-validation]
+    needs: [test, validate, type-check, lint, hacs-validation, hassfest]
     runs-on: ubuntu-latest
     if: github.event_name == 'push' && contains(github.ref, 'refs/tags/')
     permissions:

--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -27,9 +27,3 @@ jobs:
     - name: Run pre-commit
       run: |
         pre-commit run --all-files --show-diff-on-failure
-
-    - name: Run pre-commit (push only)
-      if: github.event_name == 'push'
-      run: |
-        pre-commit install
-        pre-commit run --all-files

--- a/pyrightconfig.json
+++ b/pyrightconfig.json
@@ -11,11 +11,11 @@
     "reportMissingParameterType": "none",
     "reportMissingTypeArgument": "none",
     "reportImportCycles": "none",
-    "reportUnusedImport": "warning",
-    "reportUnusedClass": "warning",
-    "reportUnusedFunction": "warning",
-    "reportUnusedVariable": "warning",
-    "reportDuplicateImport": "warning",
+    "reportUnusedImport": "error",
+    "reportUnusedClass": "error",
+    "reportUnusedFunction": "error",
+    "reportUnusedVariable": "error",
+    "reportDuplicateImport": "error",
     "pythonVersion": "3.13",
     "include": [
         "custom_components/custom_areas"


### PR DESCRIPTION
## Summary

Tightens the release gate and CI hygiene. Independent of all code changes — can land in any order.

- **H6** — Added `hassfest` to the `release` job's `needs` list. Previously the canonical HA integration validator could fail and a release would still publish.
- **New guard** — Release job now fails if `manifest.json:version` doesn't match the git tag (with `v` prefix stripped). Would have caught the `v1.3.0` tag / `1.2.0` manifest skew that Phase 1 reconciles.
- **L11** — Removed the duplicate `Run pre-commit (push only)` step in `.github/workflows/pre-commit.yml`. The second `pre-commit install` then `pre-commit run --all-files` was a no-op duplicate of the first unconditional step.
- **L10** — Escalated `reportUnusedImport`, `reportUnusedClass`, `reportUnusedFunction`, `reportUnusedVariable`, `reportDuplicateImport` in `pyrightconfig.json` from `warning` to `error`. Verified locally: zero new pyright errors on this branch's tree (pre-existing errors are unrelated and Phase 3 cleans them up).

## Commits

```
66c4418 ci(H6): add hassfest to release-job dependency list
d7ce209 ci: verify manifest version matches release tag
048ab67 ci(L11): remove duplicate pre-commit run step on push
4223650 chore(L10): escalate pyright unused-* warnings to errors
```

## Test plan

- [ ] CI green on this PR
- [ ] Once merged + after a future tag is pushed, confirm the release job either succeeds (when manifest matches) or fails with a clear `::error::` line (when they don't match)
- [ ] Confirm the `pre-commit.yml` workflow runs once per push, not twice

Generated with [Claude Code](https://claude.com/claude-code)