### PR TITLE
Phase 4: sync docs to v1.3.0 multi-entity architecture

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -124,11 +124,5 @@ dmypy.json
 .DS_Store
 Thumbs.db
 
-# Home Assistant specific
-custom_components/rooms/__pycache__/
-custom_components/rooms/*.pyc
-custom_components/rooms/*.pyo
-custom_components/rooms/*.pyd
-
 # Logs
 *.log

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-All notable changes to the Rooms integration will be documented in this file.
+All notable changes to the Custom Areas integration will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).

--- a/README.md
+++ b/README.md
@@ -166,8 +166,9 @@ This project uses GitHub Actions for continuous integration and deployment:
 - **Tests**: Run on Python 3.13
 - **Validation**: Custom validation of manifest, translations, and structure
 - **Type Checking**: Pyright type checking
-- **Linting**: Black formatting, isort import sorting, and flake8 linting
+- **Linting**: Black formatting, isort import sorting, flake8 linting, and ruff checks
 - **HACS Validation**: Ensures compatibility with HACS
+- **Hassfest**: Home Assistant's canonical integration validator
 - **Pre-commit**: Code quality checks on pull requests
 
 ### Workflows

--- a/docs/api.md
+++ b/docs/api.md
@@ -1,25 +1,41 @@
 # API Documentation
 
-## Room Sensor Entity
+## Overview
 
-The Rooms integration creates a single sensor entity per room configuration with the following properties:
+Each configured area produces a **summary sensor** plus zero to five **measurement sensors**,
+depending on which source entities you configure. All entity IDs start with
+`custom_area_<area_name>` (the area name is slugified by Home Assistant — spaces become
+underscores, etc.).
 
-### Entity ID Format
-```
-sensor.room_<room_name>_summary
-```
+| Sensor | Entity ID pattern | Created when |
+|---|---|---|
+| Summary | `sensor.custom_area_<area_name>` | Always |
+| Power | `sensor.custom_area_<area_name>_power` | `power_entity` configured |
+| Energy | `sensor.custom_area_<area_name>_energy` | `energy_entity` configured |
+| Temperature | `sensor.custom_area_<area_name>_temperature` | `temp_entity` configured |
+| Humidity | `sensor.custom_area_<area_name>_humidity` | `humidity_entity` configured |
+| Climate target | `sensor.custom_area_<area_name>_climate_target` | `climate_entity` configured |
+
+## Summary Sensor (`sensor.custom_area_<area_name>`)
+
+The summary sensor aggregates all configured source entities into a single composite
+entity for dashboards and automations. Its state, attributes, and icon are all derived
+from the underlying source entities at access time — there is no internal cached state.
 
 ### States
 
 | State | Description |
 |-------|-------------|
-| `active` | Room is currently active (motion detected OR power above threshold) |
-| `idle` | Room has configured entities but is not active |
-| `unknown` | No entities configured for the room |
+| `active` | Area is currently active (motion detected OR power above threshold) |
+| `idle` | Area has configured entities but is not active |
+| `unknown` | No entities configured for the area |
 
 ### Attributes
 
-The room sensor exposes both numeric attributes (useful for automations) and display attributes that include units in a single string for easy UI usage.
+Numeric attributes ship in **two forms**: a typed numeric attribute (e.g. `power_w`)
+useful for automations and templates, and a stringified-with-unit attribute (e.g.
+`power: "28.6 W"`) useful for direct display in cards. Both are always emitted together
+when the corresponding source entity is configured and has a valid numeric state.
 
 | Attribute | Type | Description |
 |-----------|------|-------------|
@@ -31,25 +47,66 @@ The room sensor exposes both numeric attributes (useful for automations) and dis
 | `temperature` | string | Temperature, formatted with unit (e.g., `21.5 °C`) |
 | `humidity_pct` | float | Current humidity percentage (numeric) |
 | `humidity` | string | Humidity, formatted with unit (e.g., `45 %`) |
-| `occupied` | boolean | Motion detection status |
-| `window_open` | boolean | Window/door status |
-| `climate_mode` | string | Current climate mode |
 | `climate_target_c` | float | Target temperature (numeric) |
 | `climate_target` | string | Target temperature, formatted with unit (e.g., `21 °C`) |
+| `occupied` | boolean | Motion detection status |
+| `window_open` | boolean | Window/door status |
+| `climate_mode` | string | Current climate mode (from the climate entity's state) |
+
+### State Priority
+
+The summary sensor's state follows this order (first match wins):
+
+1. **Motion ON** → `active`
+2. **Power > `active_threshold`** → `active`
+3. **Any core entity configured** → `idle`
+4. **Else** → `unknown`
+
+### Icon Priority
+
+The icon also follows a strict priority order:
+
+1. **Window open** → `mdi:window-open-variant`
+2. **Motion detected** → `mdi:motion-sensor`
+3. **Configured `icon` (or default `mdi:texture-box`)**
+
+## Measurement Sensors
+
+One measurement sensor is created per configured measurement source entity. Each
+measurement sensor is a **passthrough** — its `native_value` mirrors the source
+entity's state (or, for `climate_target`, the source entity's `temperature` attribute).
+The unit of measurement is taken from the source entity when available, otherwise it
+falls back to the listed default.
+
+| Sensor | Source attribute | Default unit |
+|---|---|---|
+| Power | `state.state` of `power_entity` | `W` |
+| Energy | `state.state` of `energy_entity` | `Wh` |
+| Temperature | `state.state` of `temp_entity` | `°C` |
+| Humidity | `state.state` of `humidity_entity` | `%` |
+| Climate target | `state.attributes["temperature"]` of `climate_entity` | `°C` |
+
+Measurement sensors expose no additional attributes — they are intentionally minimal
+so that Home Assistant's built-in formatting, statistics, and long-term history can
+treat them as first-class numeric sensors.
 
 ## Device Registry
 
-Each room creates a device in Home Assistant's device registry:
+Each area creates a single device in Home Assistant's device registry. All sensors for
+the area (summary + measurements) are attached to the same device.
 
 ### Device Properties
-- **Name**: `Room: <room_name>`
-- **Manufacturer**: `Rooms Integration`
-- **Model**: `Room Sensor`
-- **Identifiers**: `{(DOMAIN, config_entry.entry_id)}`
+- **Name**: `Area: <area_name>`
+- **Manufacturer**: `Areas Integration`
+- **Model**: `Area Sensor`
+- **Identifiers**: `{(custom_areas, config_entry.entry_id)}`
 
 ## Events
 
-The integration listens for state change events on all configured entities and updates the room sensor immediately without polling.
+The integration listens for state change events on all configured source entities and
+updates every sensor for the area immediately — no polling. When any tracked source
+entity changes state, the coordinator schedules an update for every registered sensor;
+each sensor then recomputes its state and attributes lazily on the next property access.
 
 ### Tracked Events
 - State changes on power sensors
@@ -63,21 +120,22 @@ The integration listens for state change events on all configured entities and u
 ## Configuration Schema
 
 ### Required Fields
-- `room_name`: String - Display name for the room
+- `area_name` (string) — Display name for the area; also drives the entity_id suffix.
 
 ### Optional Fields
-- `power_entity`: Entity ID - Power consumption sensor
-- `energy_entity`: Entity ID - Energy consumption sensor
-- `temperature_entity`: Entity ID - Temperature sensor
-- `humidity_entity`: Entity ID - Humidity sensor
-- `motion_entity`: Entity ID - Motion detection sensor
-- `window_entity`: Entity ID - Window/door sensor
-- `climate_entity`: Entity ID - Climate control entity
-- `active_threshold`: Float - Power threshold for active state (watts)
+- `power_entity` (entity ID, sensor domain) — Power consumption sensor (W).
+- `energy_entity` (entity ID, sensor domain) — Energy consumption sensor (Wh).
+- `temp_entity` (entity ID, sensor domain) — Temperature sensor (°C).
+- `humidity_entity` (entity ID, sensor domain) — Humidity sensor (%).
+- `motion_entity` (entity ID, binary_sensor domain) — Motion detection sensor.
+- `window_entity` (entity ID, binary_sensor domain) — Window/door sensor.
+- `climate_entity` (entity ID, climate domain) — Climate control entity.
+- `active_threshold` (float, watts) — Power threshold for the `active` state. Default: `50.0`.
+- `icon` (mdi icon string) — Fallback icon when neither window nor motion drives the icon. Default: `mdi:texture-box`.
 
 ## State Logic
 
-The room state follows this priority order:
+The area state follows this priority order:
 
 1. **Motion Detection**: If motion sensor is ON → `active`
 2. **Power Threshold**: If power consumption > active threshold → `active`
@@ -86,7 +144,7 @@ The room state follows this priority order:
 
 ## Icon Logic
 
-The sensor icon changes based on room status:
+The summary sensor icon changes based on area status:
 
 1. **Window Open**: If window sensor is ON → `mdi:window-open-variant`
 2. **Motion Detected**: If motion sensor is ON → `mdi:motion-sensor`

--- a/docs/developer.md
+++ b/docs/developer.md
@@ -2,53 +2,66 @@
 
 ## Architecture Overview
 
-The Custom Areas Integration follows Home Assistant's standard custom integration architecture with the following components:
+The Custom Areas Integration follows Home Assistant's standard custom integration architecture.
 
 ### Core Files
 
 ```
 custom_components/custom_areas/
-├── __init__.py          # Integration setup and lifecycle
-├── config_flow.py       # UI configuration flow
-├── sensor.py           # Sensor entity implementation
-├── const.py            # Constants and configuration keys
-├── manifest.json       # Integration metadata
-├── strings.json        # UI strings for config flow
+├── __init__.py          # async_setup_entry / unload / reload, device registration
+├── config_flow.py       # UI configuration flow (AreasConfigFlow)
+├── sensor.py            # Coordinator + sensor entity implementations
+├── const.py             # CONF_* keys, defaults, and shared constants
+├── manifest.json        # Integration metadata
+├── strings.json         # UI strings for config flow
 └── translations/
-    └── en.json         # English translations
+    └── en.json          # English translations
 ```
 
 ### Key Classes
 
-#### `RoomSensorCoordinator`
-- **Purpose**: Coordinates state updates between entities
+#### `AreaSensorCoordinator`
+- **Purpose**: Owns the state-change listeners for the area's configured source entities
+  and fans out updates to every sensor registered against it.
 - **Responsibilities**:
-  - Sets up event listeners for all configured entities
-  - Handles state change events
-  - Manages cleanup of listeners
-  - Registers the summary sensor for updates
+  - Subscribes to source-entity state changes via `async_track_state_change_event`.
+  - Keeps an internal list of registered sensors and schedules a Home Assistant state
+    update on each of them when any source entity changes.
+  - Manages listener cleanup at shutdown.
 
-#### `RoomSummarySensor`
-- **Purpose**: Main sensor entity that represents room state
+#### `AreaSummarySensor`
+- **Purpose**: Composite sensor entity representing the area's aggregate state.
 - **Responsibilities**:
-  - Calculates room state based on entity conditions
-  - Provides state attributes with sensor data
-  - Determines appropriate icon based on room status
-  - Handles device registry integration
+  - Computes `native_value` (state), `icon`, and `extra_state_attributes` on demand by
+    reading the configured source entities at access time — no internal cached state.
+  - Honors the documented state priority (motion > power threshold > entity presence)
+    and icon priority (window > motion > configured/default).
+  - Ships every numeric attribute in two forms: a typed numeric (`power_w`, etc.) and a
+    stringified-with-unit form (`power: "28.6 W"`).
+
+#### Measurement sensors
+- One passthrough sensor per configured measurement source (power, energy, temperature,
+  humidity, climate target). Each mirrors the source entity's `state.state` (or, for
+  climate target, the `state.attributes["temperature"]`), with the unit forwarded from
+  the source entity when available and a sensible default otherwise. They share the
+  same device registry entry as the summary sensor.
 
 ## Code Flow
 
 ### Setup Process
-1. `async_setup_entry()` creates coordinator and sensor entities
-2. Coordinator sets up state change listeners for all configured entities
-3. Sensor registers itself with the coordinator
-4. Entities are added to Home Assistant
+1. `async_setup_entry()` registers the device in Home Assistant's device registry.
+2. `AreaSensorCoordinator` is created and subscribes to state-change events on each
+   configured source entity.
+3. The summary sensor and each enabled measurement sensor are instantiated and
+   `register_sensor()`ed with the coordinator.
+4. Entities are added to Home Assistant via `async_add_entities`.
 
 ### State Update Process
-1. Entity state change triggers event
-2. Coordinator receives event and schedules sensor update
-3. Sensor recalculates state and attributes
-4. Home Assistant updates the entity state
+1. A tracked source entity emits a state-change event.
+2. The coordinator's listener fires; it schedules a Home Assistant state update on
+   every registered sensor.
+3. When Home Assistant reads each sensor's properties, the sensor recomputes its state
+   and attributes lazily from the current state of the configured source entities.
 
 ## Development Setup
 
@@ -76,23 +89,31 @@ custom_components/custom_areas/
    pip install -r requirements-dev.txt
    ```
 
-4. **Run tests**:
-   ```bash
-   python run_tests.py
-   ```
-
-5. **Run validation**:
+4. **Run validation**:
    ```bash
    python validate.py
    ```
 
+5. **Run tests**:
+   ```bash
+   python run_tests.py
+   ```
+
+6. **Full local gate**:
+   ```bash
+   python check_all.py   # validate + tests + pyright + black + isort + flake8 + pre-commit
+   ```
+
 ### Testing
 
-The project includes comprehensive tests covering:
+Tests live inside the integration package at
+`custom_components/custom_areas/tests/`. The project uses a hybrid approach:
 
-- **Unit Tests**: Core functionality and state logic
-- **Config Flow Tests**: UI configuration validation
-- **Integration Tests**: End-to-end functionality
+- **Unit tests** use `MagicMock(spec=HomeAssistant)` for fast, isolated coverage of
+  sensor and coordinator logic.
+- **Integration tests** use the real `hass` fixture from
+  `pytest-homeassistant-custom-component` to exercise the integration end-to-end against
+  the actual Home Assistant state machine.
 
 Run tests with:
 ```bash
@@ -101,12 +122,14 @@ python -m pytest custom_components/custom_areas/tests/
 
 ### Code Quality
 
-The project uses several tools for code quality:
+The project uses several tools — all enforced via pre-commit and CI:
 
-- **Black**: Code formatting
-- **isort**: Import sorting
-- **flake8**: Linting
-- **pyright**: Type checking
+- **black** — code formatter (line length **120**, not 88)
+- **isort** — import sorter (profile=black)
+- **flake8** — linter
+- **ruff** — linter (additional checks)
+- **mypy** — type checker
+- **pyright** — type checker (basic mode)
 
 Run all quality checks:
 ```bash
@@ -116,32 +139,38 @@ python check_all.py
 ## Configuration Flow
 
 ### Flow Steps
-1. **User Step**: Collects all configuration data in a single form
-2. **Validation**: Ensures room name uniqueness
-3. **Entry Creation**: Creates config entry with user data
+1. **User Step** (`async_step_user`): Collects all configuration fields in a single
+   form. Schema validation is handled by voluptuous; entity pickers are filtered by
+   domain via `EntitySelector`.
+2. **Validation**: Ensures the area name is unique across existing entries via
+   `async_set_unique_id` + `_abort_if_unique_id_configured`. The `icon` field is
+   defaulted to `mdi:texture-box` when not provided.
+3. **Entry Creation**: Creates the config entry with the user's data.
+
+> **Options flow**: planned. Changing settings on an existing area today requires
+> deleting and recreating the entry.
 
 ### Entity Selection
 The config flow uses Home Assistant's `EntitySelector` for each entity type:
-- Sensors: `sensor` domain
-- Binary sensors: `binary_sensor` domain
+- Sensors (power, energy, temperature, humidity): `sensor` domain
+- Binary sensors (motion, window): `binary_sensor` domain
 - Climate: `climate` domain
 
 ### Validation Rules
-- Room name must be unique across all room configurations
-- All selected entities must exist in Home Assistant
-- Active threshold must be a non-negative number
+- Area name must be unique across all area configurations.
+- Active threshold must be a non-negative number.
 
 ## State Management
 
 ### Event-Driven Updates
 The integration uses Home Assistant's event system for real-time updates:
-- No polling - instant response to state changes
+- No polling — instant response to state changes
 - Efficient resource usage
-- Reliable state synchronization
+- Reliable state synchronization via `async_track_state_change_event`
 
 ### State Calculation Logic
 ```python
-def determine_room_state(self) -> str:
+def determine_area_state(self) -> str:
     # Priority: Motion > Power Threshold > Entity Presence > Unknown
     if motion_detected:
         return STATE_ACTIVE
@@ -154,50 +183,39 @@ def determine_room_state(self) -> str:
 
 ### Attribute Collection
 Attributes are collected with error handling:
-- Numeric values use `_get_numeric_state()` with fallbacks
+- Numeric values use `get_numeric_state()` with fallbacks
 - Boolean values use direct state comparison
-- Climate attributes include both mode and target temperature
+- Climate attributes include both `climate_mode` (string) and `climate_target_c` / `climate_target` (numeric + stringified form)
 
 ## Error Handling
 
+### Setup Failures
+- `__init__.py` deliberately re-raises setup errors as `ConfigEntryNotReady` so that
+  Home Assistant retries setup on its standard backoff. Preserve this pattern.
+
 ### State Conversion
-- Invalid numeric states log debug messages and use defaults
-- Missing entities are gracefully handled
-- Type conversion errors are caught and logged
+- Invalid numeric states log debug messages and are skipped (the attribute is omitted
+  rather than set to a bad value).
+- Missing entities are gracefully handled.
+- Type conversion errors are caught and logged.
 
 ### Listener Management
-- Listeners are properly cleaned up on shutdown
-- Coordinator manages listener lifecycle
-- Prevents memory leaks and duplicate listeners
+- Listeners are properly cleaned up on shutdown by the coordinator.
+- The coordinator manages listener lifecycle to prevent memory leaks and duplicate
+  listeners.
 
 ## Performance Considerations
 
-### Caching
-- State lookups are cached within attribute calculation
-- Reduces redundant state access
-- Improves performance with multiple attributes
-
 ### Event Filtering
-- Only tracks configured entities
-- Uses specific entity IDs rather than wildcards
-- Minimizes event processing overhead
+- Only tracks configured entities — uses specific entity IDs rather than wildcards.
+- Minimizes event processing overhead.
 
 ### Memory Management
-- Coordinator properly cleans up listeners
-- No persistent state storage beyond config entries
-- Lightweight entity implementation
+- The coordinator cleans up its listeners on shutdown.
+- No persistent state storage beyond the config entry.
+- Lightweight entity implementation: sensors compute lazily on property access.
 
 ## Future Enhancements
 
-### Potential Features
-- Multiple room types with different logic
-- Room groups and hierarchies
-- Historical state tracking
-- Automation integration
-- Energy monitoring dashboards
-
-### Architecture Improvements
-- Async state calculation
-- Configurable state priorities
-- Plugin system for custom logic
-- Enhanced error reporting
+For the latest planned work, see the [CHANGELOG](../CHANGELOG.md) and the project's
+issue tracker.

--- a/docs/examples.md
+++ b/docs/examples.md
@@ -1,22 +1,22 @@
 # Configuration Examples
 
-This document provides practical examples of how to configure rooms for different scenarios.
+This document provides practical examples of how to configure areas for different scenarios.
 
-## Basic Room Configuration
+## Basic Area Configuration
 
 ### Living Room with Motion Detection
 ```
-Room Name: Living Room
+Area Name: Living Room
 Motion Sensor: binary_sensor.living_room_motion
 Temperature Sensor: sensor.living_room_temperature
 Active Power Threshold: 10
 ```
 
-**Use Case**: Basic room monitoring with motion detection and temperature tracking.
+**Use Case**: Basic area monitoring with motion detection and temperature tracking.
 
 ### Home Office with Power Monitoring
 ```
-Room Name: Home Office
+Area Name: Home Office
 Power Sensor: sensor.home_office_power
 Motion Sensor: binary_sensor.home_office_motion
 Temperature Sensor: sensor.home_office_temperature
@@ -29,7 +29,7 @@ Active Power Threshold: 50
 
 ### Kitchen with Multiple Sensors
 ```
-Room Name: Kitchen
+Area Name: Kitchen
 Power Sensor: sensor.kitchen_power
 Motion Sensor: binary_sensor.kitchen_motion
 Temperature Sensor: sensor.kitchen_temperature
@@ -42,7 +42,7 @@ Active Power Threshold: 25
 
 ### Bedroom with Climate Control
 ```
-Room Name: Master Bedroom
+Area Name: Master Bedroom
 Motion Sensor: binary_sensor.master_bedroom_motion
 Temperature Sensor: sensor.master_bedroom_temperature
 Humidity Sensor: sensor.master_bedroom_humidity
@@ -55,7 +55,7 @@ Active Power Threshold: 5
 
 ### Bathroom with Ventilation
 ```
-Room Name: Main Bathroom
+Area Name: Main Bathroom
 Motion Sensor: binary_sensor.bathroom_motion
 Humidity Sensor: sensor.bathroom_humidity
 Window Sensor: binary_sensor.bathroom_window
@@ -68,7 +68,7 @@ Active Power Threshold: 15
 
 ### Home Theater Setup
 ```
-Room Name: Home Theater
+Area Name: Home Theater
 Power Sensor: sensor.av_receiver_power
 Motion Sensor: binary_sensor.home_theater_motion
 Temperature Sensor: sensor.home_theater_temperature
@@ -79,26 +79,26 @@ Active Power Threshold: 20
 
 ### Laundry Room
 ```
-Room Name: Laundry Room
+Area Name: Laundry Room
 Power Sensor: sensor.washer_power
 Motion Sensor: binary_sensor.laundry_motion
 Temperature Sensor: sensor.laundry_temperature
 Active Power Threshold: 10
 ```
 
-**Use Case**: Utility room with appliance power monitoring.
+**Use Case**: Utility area with appliance power monitoring.
 
 ## Automation Integration Examples
 
 ### Lighting Automation Trigger
-Use the room state in automations:
+Use the area state in automations:
 
 ```yaml
 automation:
   - alias: "Living Room Lights On"
     trigger:
       platform: state
-      entity_id: sensor.living_room_summary
+      entity_id: sensor.custom_area_living_room
       to: 'active'
     action:
       service: light.turn_on
@@ -111,7 +111,7 @@ automation:
   - alias: "Bedroom Climate Control"
     trigger:
       platform: state
-      entity_id: sensor.master_bedroom_summary
+      entity_id: sensor.custom_area_master_bedroom
       to: 'active'
     action:
       service: climate.set_temperature
@@ -126,68 +126,68 @@ automation:
   - alias: "Kitchen Window Alert"
     trigger:
       platform: state
-      entity_id: sensor.kitchen_summary
+      entity_id: sensor.custom_area_kitchen
       attribute: window_open
       to: true
     condition:
       condition: state
-      entity_id: sensor.kitchen_summary
+      entity_id: sensor.custom_area_kitchen
       state: 'idle'
     action:
       service: notify.mobile_app
       data:
-        message: "Kitchen window opened while room is unoccupied"
+        message: "Kitchen window opened while area is unoccupied"
 ```
 
 ## Dashboard Examples
 
-### Room Status Card
+### Area Status Card
 ```yaml
 type: entities
 entities:
-  - entity: sensor.living_room_summary
+  - entity: sensor.custom_area_living_room
   - type: attribute
-    entity: sensor.living_room_summary
+    entity: sensor.custom_area_living_room
   attribute: temperature
     name: Temperature
   - type: attribute
-    entity: sensor.living_room_summary
+    entity: sensor.custom_area_living_room
   attribute: power
   name: Power
   - type: attribute
-    entity: sensor.living_room_summary
+    entity: sensor.custom_area_living_room
     attribute: occupied
     name: Motion Detected
 ```
 
-### Multi-Room Overview
+### Multi-Area Overview
 ```yaml
 type: glance
-title: Room Status
+title: Area Status
 entities:
-  - sensor.living_room_summary
-  - sensor.kitchen_summary
-  - sensor.home_office_summary
-  - sensor.master_bedroom_summary
+  - sensor.custom_area_living_room
+  - sensor.custom_area_kitchen
+  - sensor.custom_area_home_office
+  - sensor.custom_area_master_bedroom
 ```
 
 ## Troubleshooting Examples
 
 ### Debug State Attributes
-Check all attributes of a room sensor:
+Check all attributes of an area sensor:
 ```yaml
 service: system_log.write
 data:
-  message: "Room attributes: {{ state_attr('sensor.living_room_summary', 'all') }}"
+  message: "Area attributes: {{ state_attr('sensor.custom_area_living_room', 'all') }}"
 ```
 
 ### Monitor State Changes
 ```yaml
 automation:
-  - alias: "Room State Monitor"
+  - alias: "Area State Monitor"
     trigger:
       platform: state
-      entity_id: sensor.living_room_summary
+      entity_id: sensor.custom_area_living_room
     action:
       service: system_log.write
       data:
@@ -197,12 +197,12 @@ automation:
 ## Best Practices
 
 ### Sensor Selection
-- Choose sensors that accurately represent room activity
-- Use appropriate power thresholds for different room types
+- Choose sensors that accurately represent area activity
+- Use appropriate power thresholds for different area types
 - Consider both motion and power for comprehensive detection
 
 ### Naming Conventions
-- Use descriptive room names
+- Use descriptive area names
 - Keep names consistent with your Home Assistant entity naming
 - Include location context when needed
 
@@ -212,6 +212,6 @@ automation:
 - Adjust based on false positives/negatives
 
 ### Entity Organization
-- Group related sensors by room
+- Group related sensors by area
 - Use consistent naming patterns
 - Document sensor purposes in entity names

--- a/docs/index.md
+++ b/docs/index.md
@@ -22,7 +22,7 @@ Welcome to the Custom Areas Integration documentation! This comprehensive docume
 ## 📋 Key Features
 
 - ✅ **UI Configuration** - Easy setup through Home Assistant's interface
-- ✅ **Composite Sensors** - Single sensor representing multiple room aspects
+- ✅ **Composite Sensors** - Summary sensor (plus per-measurement passthroughs) representing multiple area aspects
 - ✅ **Real-time Updates** - Event-driven updates, no polling required
 - ✅ **Device Registry** - Proper integration with Home Assistant's device system
 - ✅ **Flexible Configuration** - Support for power, energy, temperature, humidity, motion, windows, and climate entities
@@ -32,7 +32,7 @@ Welcome to the Custom Areas Integration documentation! This comprehensive docume
 The integration consists of:
 - **Config Flow** - Handles UI configuration and validation
 - **Sensor Coordinator** - Manages state updates and event listeners
-- **Area Sensor** - Main entity providing room state and attributes
+- **Area Sensor** - Main entity providing area state and attributes
 - **Device Registry** - Creates proper device entries
 
 ## 🔧 Development
@@ -93,7 +93,7 @@ We welcome contributions! See the [Contributing section](../README.md#contributi
 ## 📈 Roadmap
 
 Future enhancements may include:
-- Room hierarchies and grouping
+- Area hierarchies and grouping
 - Enhanced energy monitoring
 - Historical analytics
 - Advanced automation templates

--- a/docs/rationale.md
+++ b/docs/rationale.md
@@ -1,9 +1,9 @@
 # Design rationale
-This custom integration was created to deliver a room-level entity that works hand‑in‑hand with the [Custom Features for Home Assistant Cards](https://github.com/Nerwyn/custom-card-features) extension, allowing dashboards to mirror the Area card’s high‑level UX while remaining portable and source‑of‑truth agnostic, you are in control of areas' behavior. In addition, combining this integration with Custom Features for Home Assistant Cards unlocks more flexible card behaviors without being restricted to the Area logic and features. For example Area cards do not support showing a badge when a window is open, or when the AC is on, or changing the icon color based on temperature or humidity ranges. This integration exposes a stable schema that works well with Custom Features for Home Assistant Cards to implement these behaviors declaratively.
+This custom integration was created to deliver an area-level entity that works hand‑in‑hand with the [Custom Features for Home Assistant Cards](https://github.com/Nerwyn/custom-card-features) extension, allowing dashboards to mirror the Area card’s high‑level UX while remaining portable and source‑of‑truth agnostic, you are in control of areas' behavior. In addition, combining this integration with Custom Features for Home Assistant Cards unlocks more flexible card behaviors without being restricted to the Area logic and features. For example Area cards do not support showing a badge when a window is open, or when the AC is on, or changing the icon color based on temperature or humidity ranges. This integration exposes a stable schema that works well with Custom Features for Home Assistant Cards to implement these behaviors declaratively.
 
 Why not just use Areas? Two reasons:
 
-- Area entities aren’t first‑class, queryable sensors. They’re a grouping concept. Many dashboards still need a single, reactive entity per room that can provide a summary state and attributes for power, climate, occupancy, etc.
+- Area entities aren’t first‑class, queryable sensors. They’re a grouping concept. Many dashboards still need a single, reactive entity per area that can provide a summary state and attributes for power, climate, occupancy, etc.
 - The Area card’s behavior is great for overview dashboards, but it’s not easily reproducible across themes or custom dashboards without writing glue logic. This integration exposes a predictable sensor that pairs nicely with Custom Features for Home Assistant Cards’s rules and feature toggles.
 
 The integration makes it straightforward to reproduce Area card behavior on a Tile card using Custom Features for Home Assistant Cards.
@@ -12,14 +12,14 @@ The integration makes it straightforward to reproduce Area card behavior on a Ti
 
 ## Goals
 
-- Provide a single sensor per room that reflects “Active/Idle/Unknown” status.
+- Provide a summary sensor per area (plus per-measurement passthrough sensors) that reflects “Active/Idle/Unknown” status.
 - Surface useful, typed attributes (numeric + display‑friendly) to power flexible dashboards and automations.
 - Keep configuration simple: point to existing entities (power, energy, temp, humidity, motion, window, climate) without forcing a data model.
 - Be resilient across HA versions by gracefully handling missing constants and entities.
 
 ## How it works
 
-- A `sensor` entity is created per configured room. Its friendly name is the room name; suggested object_id is `room_<name>` so your entity_id becomes easy to reference in UI config and automations.
+- A summary `sensor` entity is created per configured area. Its friendly name is the area name; suggested object_id is `custom_area_<name>` so your entity_id becomes easy to reference in UI config and automations. Additional passthrough sensors are created for each configured measurement source (power, energy, temperature, humidity, climate target).
 - The state logic prioritizes “occupied” signals:
   1) If motion is ON → `active`.
   2) Else, if power exceeds `active_threshold` (default 50W) → `active`.
@@ -33,15 +33,15 @@ The integration makes it straightforward to reproduce Area card behavior on a Ti
 
 ## Why this pairs well with Custom Features for Home Assistant Cards
 
-Custom Features for Home Assistant Cards lets you declaratively toggle and compose per‑card features based on entity attributes, thresholds, and state. By centralizing room summary data in a single entity:
+Custom Features for Home Assistant Cards lets you declaratively toggle and compose per‑card features based on entity attributes, thresholds, and state. By centralizing area summary data in a single entity:
 
 - You can implement area‑like tiles with conditions like “show occupied badge when `occupied` is true”, “show window alert when `window_open` is true”, or “color accent when `state == active` or `power_w > N`”.
-- You avoid repetitive template sensors: dashboards read a consistent schema, regardless of which underlying devices a room has.
+- You avoid repetitive template sensors: dashboards read a consistent schema, regardless of which underlying devices an area has.
 - Cards remain simple: fewer jinja templates, more declarative feature rules.
 
 ## Configuration surface
 
-The integration accepts the following entity references per room:
+The integration accepts the following entity references per area:
 
 - Power sensor (W)
 - Energy sensor (Wh)
@@ -53,7 +53,7 @@ The integration accepts the following entity references per room:
 
 Optional settings:
 
-- `active_threshold`: Power threshold (W) to consider the room active when motion is off. Default: 50.0
+- `active_threshold`: Power threshold (W) to consider the area active when motion is off. Default: 50.0
 - `icon`: Fallback icon when neither motion nor window is active.
 
 ## Design choices
@@ -79,4 +79,4 @@ Optional settings:
 - Change icon color based on `humidity_pct` or `temperature_c` ranges.
 - Conditionally reveal a secondary line like `power` or `climate_target` when present.
 
-With a stable, documented schema, you can compose these behaviors per room without duplicating logic across cards.
+With a stable, documented schema, you can compose these behaviors per area without duplicating logic across cards.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,5 +1,5 @@
-site_name: Rooms Integration Documentation
-site_description: Documentation for the Rooms custom integration for Home Assistant
+site_name: Custom Areas Integration Documentation
+site_description: Documentation for the Custom Areas custom integration for Home Assistant
 site_author: Tsakiridis Ilias
 site_url: https://DefinitelyADev.github.io/room-entity
 


### PR DESCRIPTION
## Summary

Completes the long-deferred rename of \`Room*\` → \`Area*\` across the documentation surfaces. The Python code finished this rename a while back; the docs were stuck describing the old single-entity-per-room model.

- **docs/api.md** — Full rewrite. Now documents the multi-entity architecture (summary sensor + up to 5 measurement sensors), correct entity-id patterns (\`sensor.custom_area_<area_name>\`), full attribute table including the dual-form attrs Phase 1 restored, and the actual device-registry shape.
- **docs/developer.md** — \`AreaSensorCoordinator\`/\`AreaSummarySensor\` (not \`RoomSensorCoordinator\`/\`RoomSummarySensor\`), \`get_numeric_state\` (no underscore prefix), correct dev-setup commands.
- **docs/rationale.md** — Terminology pass to areas, preserved the Custom Features for Home Assistant Cards framing.
- **docs/examples.md** — Entity IDs and labels updated to area-flavored names.
- **mkdocs.yml** — \`site_name\`/\`site_description\` updated. The legacy \`DefinitelyADev/room-entity\` URLs in \`site_url\`/\`repo_*\` are preserved per AGENTS.md's "intentional aliases" note.
- **README.md** — CI section now lists \`ruff\` and \`hassfest\` (both run in CI but weren't listed).
- **CHANGELOG.md** — Header changed from "Rooms integration" to "Custom Areas integration".
- **.gitignore** — Dropped the stale \`custom_components/rooms/\` stanza (the integration is \`custom_components/custom_areas/\` now).

## Commits

\`\`\`
f8097f7 docs(M8-a): rewrite api.md for v1.2.0+ multi-entity architecture
0537807 docs(M8-b): rewrite developer.md with current class names
2bcc339 docs(M8-c): update rationale.md terminology to areas
612b276 docs(M8-d): update examples.md entity IDs and labels
2ceb8b2 docs(M8-e,g): update mkdocs metadata, README CI section, CHANGELOG header
b2eae5a chore(M8-f): drop stale rooms stanza from .gitignore
7d1d657 docs(M8): clean up remaining room references in docs/index.md
\`\`\`

## Test plan

- [ ] CI green
- [ ] \`mkdocs serve\` locally and click through Home / Rationale / API / Examples / Developer — entity IDs, manufacturer name, attribute table all match reality
- [ ] Confirm no remaining \`Room*\`/\`room_name\` references except the deliberate URL aliases

## Stacking note

Branched off \`phase-1-contract-restoration\`. Diff against master includes Phase 1's commits; auto-narrows once Phase 1 merges.

## Known follow-up (small)

After Phase 3 (#options-flow) lands, \`docs/developer.md\` line 150 still says *"Options flow: planned"* — that paragraph needs a one-liner update describing \`AreasOptionsFlowHandler\`. Can fold into Phase 2's rebase commit or land as a trivial follow-up.

Generated with [Claude Code](https://claude.com/claude-code)