### PR TITLE
Phase 3: options flow, M1 sensor collapse, code-quality cleanups

### DIFF
--- a/custom_components/custom_areas/__init__.py
+++ b/custom_components/custom_areas/__init__.py
@@ -7,7 +7,7 @@ from homeassistant.core import HomeAssistant
 from homeassistant.exceptions import ConfigEntryNotReady
 from homeassistant.helpers import device_registry as dr
 
-from .const import DOMAIN
+from .const import CONF_AREA_NAME, DOMAIN
 from .sensor import AreaSensorCoordinator
 
 _LOGGER = logging.getLogger(__name__)
@@ -31,7 +31,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
         device_registry.async_get_or_create(
             config_entry_id=entry.entry_id,
             identifiers={(DOMAIN, entry.entry_id)},
-            name=f"Area: {entry.data.get('area_name', 'Unknown')}",
+            name=f"Area: {entry.data.get(CONF_AREA_NAME, 'Unknown')}",
             manufacturer="Areas Integration",
             model="Area Sensor",
         )

--- a/custom_components/custom_areas/__init__.py
+++ b/custom_components/custom_areas/__init__.py
@@ -43,11 +43,11 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
         return True
 
     except Exception as ex:
-        _LOGGER.error("Error setting up areas integration: %s", ex)
-        _LOGGER.error("Exception type: %s", type(ex).__name__)
-        import traceback
-
-        _LOGGER.error("Full traceback: %s", traceback.format_exc())
+        # HA itself logs ConfigEntryNotReady with context and retries setup
+        # on a backoff. Emit one structured warning (exc_info=ex includes the
+        # traceback) and let HA handle the retry messaging. Use `warning`
+        # rather than `error` since setup retries are routine on restart.
+        _LOGGER.warning("Setup failed for %s: %s", entry.title, ex, exc_info=ex)
         raise ConfigEntryNotReady from ex
 
 

--- a/custom_components/custom_areas/__init__.py
+++ b/custom_components/custom_areas/__init__.py
@@ -59,7 +59,7 @@ async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
 
     if unload_ok:
         coordinator = hass.data[DOMAIN].pop(entry.entry_id)
-        coordinator.async_shutdown()
+        coordinator.shutdown()
 
     return unload_ok
 

--- a/custom_components/custom_areas/config_flow.py
+++ b/custom_components/custom_areas/config_flow.py
@@ -39,11 +39,6 @@ class AreasConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
     """Handle a config flow for Areas."""
 
     VERSION = 1
-    DOMAIN = DOMAIN
-
-    def __init__(self):
-        """Initialize the config flow."""
-        self._data = {}
 
     @staticmethod
     def async_get_options_flow(config_entry: ConfigEntry) -> "AreasOptionsFlowHandler":

--- a/custom_components/custom_areas/config_flow.py
+++ b/custom_components/custom_areas/config_flow.py
@@ -5,7 +5,7 @@ from typing import Any, Dict, Optional
 
 import voluptuous as vol
 from homeassistant import config_entries
-from homeassistant.config_entries import ConfigFlowResult
+from homeassistant.config_entries import ConfigEntry, ConfigFlowResult
 from homeassistant.helpers import selector
 
 from .const import (
@@ -35,6 +35,11 @@ class AreasConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
     def __init__(self):
         """Initialize the config flow."""
         self._data = {}
+
+    @staticmethod
+    def async_get_options_flow(config_entry: ConfigEntry) -> "AreasOptionsFlowHandler":
+        """Return the options flow handler for an existing entry."""
+        return AreasOptionsFlowHandler(config_entry)
 
     async def async_step_user(self, user_input: Optional[Dict[str, Any]] = None) -> ConfigFlowResult:
         """Handle the initial step."""
@@ -88,3 +93,65 @@ class AreasConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
             ),
             errors=errors,
         )
+
+
+class AreasOptionsFlowHandler(config_entries.OptionsFlow):
+    """Handle reconfiguring an existing area entry.
+
+    Mirrors `AreasConfigFlow.async_step_user`'s schema without the
+    unique-id check (the entry already exists). Defaults pull from
+    `entry.options` first, falling back to `entry.data`, so a partially-
+    edited entry keeps unchanged fields.
+    """
+
+    def __init__(self, config_entry: ConfigEntry) -> None:
+        """Capture the entry being reconfigured."""
+        self.config_entry = config_entry
+
+    async def async_step_init(self, user_input: Optional[Dict[str, Any]] = None) -> ConfigFlowResult:
+        """Show the options form, then save into `entry.options`."""
+        if user_input is not None:
+            # Ensure icon has a default value if not provided
+            if CONF_ICON not in user_input or user_input[CONF_ICON] is None:
+                user_input[CONF_ICON] = DEFAULT_ICON
+
+            return self.async_create_entry(title="", data=user_input)
+
+        def _current(key: str) -> Any:
+            """Options take precedence over data for default values."""
+            if key in self.config_entry.options:
+                return self.config_entry.options[key]
+            return self.config_entry.data.get(key)
+
+        schema: dict[Any, Any] = {
+            vol.Required(CONF_AREA_NAME, default=_current(CONF_AREA_NAME)): str,
+        }
+
+        # Optional fields default to `vol.UNDEFINED` if neither options nor data
+        # has them set — voluptuous treats that as "no default" rather than
+        # rendering an empty entity selector with None.
+        for key, sel in (
+            (CONF_ICON, selector.IconSelector(selector.IconSelectorConfig(placeholder="mdi:texture-box"))),
+            (CONF_POWER_ENTITY, selector.EntitySelector(selector.EntitySelectorConfig(domain="sensor"))),
+            (CONF_ENERGY_ENTITY, selector.EntitySelector(selector.EntitySelectorConfig(domain="sensor"))),
+            (CONF_TEMP_ENTITY, selector.EntitySelector(selector.EntitySelectorConfig(domain="sensor"))),
+            (CONF_HUMIDITY_ENTITY, selector.EntitySelector(selector.EntitySelectorConfig(domain="sensor"))),
+            (CONF_MOTION_ENTITY, selector.EntitySelector(selector.EntitySelectorConfig(domain="binary_sensor"))),
+            (CONF_WINDOW_ENTITY, selector.EntitySelector(selector.EntitySelectorConfig(domain="binary_sensor"))),
+            (CONF_CLIMATE_ENTITY, selector.EntitySelector(selector.EntitySelectorConfig(domain="climate"))),
+        ):
+            current = _current(key)
+            if current is not None:
+                schema[vol.Optional(key, default=current)] = sel
+            else:
+                schema[vol.Optional(key)] = sel
+
+        threshold_default = _current(CONF_ACTIVE_THRESHOLD)
+        if threshold_default is not None:
+            schema[vol.Optional(CONF_ACTIVE_THRESHOLD, default=threshold_default)] = vol.All(
+                vol.Coerce(float), vol.Range(min=0)
+            )
+        else:
+            schema[vol.Optional(CONF_ACTIVE_THRESHOLD)] = vol.All(vol.Coerce(float), vol.Range(min=0))
+
+        return self.async_show_form(step_id="init", data_schema=vol.Schema(schema))

--- a/custom_components/custom_areas/config_flow.py
+++ b/custom_components/custom_areas/config_flow.py
@@ -7,6 +7,7 @@ import voluptuous as vol
 from homeassistant import config_entries
 from homeassistant.config_entries import ConfigEntry, ConfigFlowResult
 from homeassistant.helpers import selector
+from homeassistant.util import slugify
 
 from .const import (
     CONF_ACTIVE_THRESHOLD,
@@ -46,8 +47,10 @@ class AreasConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
         errors: Dict[str, str] = {}
 
         if user_input is not None:
-            # Validate area name is unique
-            await self.async_set_unique_id(user_input[CONF_AREA_NAME])
+            # Validate area name is unique. Slugify first so "Living Room",
+            # "living room", and " Living Room " all collide on the same
+            # unique_id rather than coexisting as separate entries.
+            await self.async_set_unique_id(slugify(user_input[CONF_AREA_NAME]))
             self._abort_if_unique_id_configured()
 
             # Ensure icon has a default value if not provided

--- a/custom_components/custom_areas/config_flow.py
+++ b/custom_components/custom_areas/config_flow.py
@@ -1,6 +1,5 @@
 """Config flow for Custom Areas Integration."""
 
-import logging
 from typing import TYPE_CHECKING, Any, Dict, Optional
 
 import voluptuous as vol
@@ -32,8 +31,6 @@ from .const import (
     DEFAULT_ICON,
     DOMAIN,
 )
-
-_LOGGER = logging.getLogger(__name__)
 
 
 class AreasConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):

--- a/custom_components/custom_areas/config_flow.py
+++ b/custom_components/custom_areas/config_flow.py
@@ -114,8 +114,15 @@ class AreasOptionsFlowHandler(config_entries.OptionsFlow):
     """
 
     def __init__(self, config_entry: ConfigEntry) -> None:
-        """Capture the entry being reconfigured."""
-        self.config_entry = config_entry
+        """Capture the entry being reconfigured.
+
+        Stored on a private attribute (`_entry`) rather than
+        ``self.config_entry``: in newer Home Assistant releases
+        ``OptionsFlow.config_entry`` is a framework-provided read-only
+        property, so the subclass cannot assign to it. The private name
+        works across all supported HA versions.
+        """
+        self._entry = config_entry
 
     async def async_step_init(self, user_input: Optional[Dict[str, Any]] = None) -> "ConfigFlowResult":
         """Show the options form, then save into `entry.options`."""
@@ -128,9 +135,9 @@ class AreasOptionsFlowHandler(config_entries.OptionsFlow):
 
         def _current(key: str) -> Any:
             """Options take precedence over data for default values."""
-            if key in self.config_entry.options:
-                return self.config_entry.options[key]
-            return self.config_entry.data.get(key)
+            if key in self._entry.options:
+                return self._entry.options[key]
+            return self._entry.data.get(key)
 
         schema: dict[Any, Any] = {
             vol.Required(CONF_AREA_NAME, default=_current(CONF_AREA_NAME)): str,

--- a/custom_components/custom_areas/config_flow.py
+++ b/custom_components/custom_areas/config_flow.py
@@ -28,6 +28,7 @@ from .const import (
     CONF_POWER_ENTITY,
     CONF_TEMP_ENTITY,
     CONF_WINDOW_ENTITY,
+    DEFAULT_ACTIVE_THRESHOLD,
     DEFAULT_ICON,
     DOMAIN,
 )
@@ -94,7 +95,9 @@ class AreasConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
                     vol.Optional(CONF_CLIMATE_ENTITY): selector.EntitySelector(
                         selector.EntitySelectorConfig(domain="climate")
                     ),
-                    vol.Optional(CONF_ACTIVE_THRESHOLD): vol.All(vol.Coerce(float), vol.Range(min=0)),
+                    vol.Optional(CONF_ACTIVE_THRESHOLD, default=DEFAULT_ACTIVE_THRESHOLD): vol.All(
+                        vol.Coerce(float), vol.Range(min=0)
+                    ),
                 }
             ),
             errors=errors,

--- a/custom_components/custom_areas/config_flow.py
+++ b/custom_components/custom_areas/config_flow.py
@@ -95,9 +95,12 @@ class AreasConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
                     vol.Optional(CONF_CLIMATE_ENTITY): selector.EntitySelector(
                         selector.EntitySelectorConfig(domain="climate")
                     ),
-                    vol.Optional(CONF_ACTIVE_THRESHOLD, default=DEFAULT_ACTIVE_THRESHOLD): vol.All(
-                        vol.Coerce(float), vol.Range(min=0)
-                    ),
+                    # default= argument fights voluptuous's `Undefined`-typed stubs.
+                    # The runtime accepts any default; the suppress silences pyright.
+                    vol.Optional(
+                        CONF_ACTIVE_THRESHOLD,
+                        default=DEFAULT_ACTIVE_THRESHOLD,  # pyright: ignore[reportArgumentType]
+                    ): vol.All(vol.Coerce(float), vol.Range(min=0)),
                 }
             ),
             errors=errors,

--- a/custom_components/custom_areas/config_flow.py
+++ b/custom_components/custom_areas/config_flow.py
@@ -1,13 +1,21 @@
 """Config flow for Custom Areas Integration."""
 
 import logging
-from typing import Any, Dict, Optional
+from typing import TYPE_CHECKING, Any, Dict, Optional
 
 import voluptuous as vol
 from homeassistant import config_entries
-from homeassistant.config_entries import ConfigEntry, ConfigFlowResult
+from homeassistant.config_entries import ConfigEntry
 from homeassistant.helpers import selector
 from homeassistant.util import slugify
+
+if TYPE_CHECKING:
+    # `ConfigFlowResult` only exists on newer HA versions. The CI matrix
+    # spans HA 2024/2025/2026; the locally-installed phacc-pinned HA used
+    # for type-checking may not expose it. Pull it in under TYPE_CHECKING
+    # only and use the string forward reference in signatures. The suppress
+    # below is needed because pyright still evaluates TYPE_CHECKING blocks.
+    from homeassistant.config_entries import ConfigFlowResult  # pyright: ignore[reportAttributeAccessIssue]
 
 from .const import (
     CONF_ACTIVE_THRESHOLD,
@@ -42,7 +50,7 @@ class AreasConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
         """Return the options flow handler for an existing entry."""
         return AreasOptionsFlowHandler(config_entry)
 
-    async def async_step_user(self, user_input: Optional[Dict[str, Any]] = None) -> ConfigFlowResult:
+    async def async_step_user(self, user_input: Optional[Dict[str, Any]] = None) -> "ConfigFlowResult":
         """Handle the initial step."""
         errors: Dict[str, str] = {}
 
@@ -111,7 +119,7 @@ class AreasOptionsFlowHandler(config_entries.OptionsFlow):
         """Capture the entry being reconfigured."""
         self.config_entry = config_entry
 
-    async def async_step_init(self, user_input: Optional[Dict[str, Any]] = None) -> ConfigFlowResult:
+    async def async_step_init(self, user_input: Optional[Dict[str, Any]] = None) -> "ConfigFlowResult":
         """Show the options form, then save into `entry.options`."""
         if user_input is not None:
             # Ensure icon has a default value if not provided

--- a/custom_components/custom_areas/sensor.py
+++ b/custom_components/custom_areas/sensor.py
@@ -1,7 +1,8 @@
 """Sensor platform for Custom Areas Integration."""
 
 import logging
-from typing import Any, Callable, Dict, Optional
+from collections.abc import Callable
+from typing import Any
 
 from homeassistant.components.sensor import SensorEntity
 from homeassistant.config_entries import ConfigEntry
@@ -46,7 +47,7 @@ UNIT_WATT_HOUR: str = UnitOfEnergy.WATT_HOUR
 _LOGGER = logging.getLogger(__name__)
 
 
-def get_numeric_state(hass: HomeAssistant, entity_id: str) -> Optional[float]:
+def get_numeric_state(hass: HomeAssistant, entity_id: str) -> float | None:
     """Get numeric state from entity.
 
     Returns the parsed float value, or None if the entity doesn't exist
@@ -207,11 +208,11 @@ class AreaSummarySensor(SensorEntity):
         # References to measurement sensors. Attribute names kept (`power_sensor`
         # etc.) for backward compatibility; the concrete type is now the
         # parameterized AreaMeasurementSensor.
-        self.power_sensor: Optional["AreaMeasurementSensor"] = None
-        self.energy_sensor: Optional["AreaMeasurementSensor"] = None
-        self.temperature_sensor: Optional["AreaMeasurementSensor"] = None
-        self.humidity_sensor: Optional["AreaMeasurementSensor"] = None
-        self.climate_target_sensor: Optional["AreaMeasurementSensor"] = None
+        self.power_sensor: "AreaMeasurementSensor | None" = None
+        self.energy_sensor: "AreaMeasurementSensor | None" = None
+        self.temperature_sensor: "AreaMeasurementSensor | None" = None
+        self.humidity_sensor: "AreaMeasurementSensor | None" = None
+        self.climate_target_sensor: "AreaMeasurementSensor | None" = None
 
         # Register with coordinator
         coordinator.register_sensor(self)
@@ -231,7 +232,7 @@ class AreaSummarySensor(SensorEntity):
         return str(area_name) if area_name else ""
 
     @property
-    def suggested_object_id(self) -> Optional[str]:
+    def suggested_object_id(self) -> str | None:
         """Suggest object_id so entity_id gets a area_ prefix.
 
         Home Assistant will slugify this into the final object_id.
@@ -300,9 +301,9 @@ class AreaSummarySensor(SensorEntity):
         return str(icon_value) if icon_value is not None else DEFAULT_ICON
 
     @property
-    def extra_state_attributes(self) -> Dict[str, Any]:
+    def extra_state_attributes(self) -> dict[str, Any]:
         """Return the state attributes."""
-        attrs: Dict[str, Any] = {}
+        attrs: dict[str, Any] = {}
 
         # Binary sensor attributes (motion, window, climate mode)
         motion_entity = _get_option(self.config_entry, CONF_MOTION_ENTITY)
@@ -397,7 +398,7 @@ class AreaMeasurementSensor(SensorEntity):
         suffix: str,
         name_suffix: str,
         default_unit: str,
-        source_attribute: Optional[str] = None,
+        source_attribute: str | None = None,
     ) -> None:
         """Initialize a measurement sensor.
 
@@ -435,13 +436,13 @@ class AreaMeasurementSensor(SensorEntity):
         coordinator.register_sensor(self)
 
     @property
-    def suggested_object_id(self) -> Optional[str]:
+    def suggested_object_id(self) -> str | None:
         """Suggest object_id (HA slugifies this for the final entity_id)."""
         area_name = str(_get_option(self.config_entry, CONF_AREA_NAME, "")).strip()
         return f"custom_area_{area_name}_{self._suffix}" if area_name else None
 
     @property
-    def native_value(self) -> Optional[float]:
+    def native_value(self) -> float | None:
         """Return the state of the sensor.
 
         For non-climate sensors (`source_attribute is None`): the parsed
@@ -468,7 +469,7 @@ class AreaMeasurementSensor(SensorEntity):
         return None
 
     @property
-    def native_unit_of_measurement(self) -> Optional[str]:
+    def native_unit_of_measurement(self) -> str | None:
         """Return the unit of measurement.
 
         Returns the source entity's `unit_of_measurement` attribute when

--- a/custom_components/custom_areas/sensor.py
+++ b/custom_components/custom_areas/sensor.py
@@ -166,7 +166,7 @@ class AreaSensorCoordinator:
             _LOGGER.debug("Successfully registered state change listener")
 
     @callback
-    def _handle_state_change(self, _event: Event) -> None:
+    def _handle_state_change(self, _: Event) -> None:
         """Handle state change events."""
         # Update all registered sensors
         for sensor in self._sensors:

--- a/custom_components/custom_areas/sensor.py
+++ b/custom_components/custom_areas/sensor.py
@@ -194,8 +194,9 @@ class AreaSummarySensor(SensorEntity):
         """Initialize the sensor."""
         self.coordinator = coordinator
         self.config_entry = config_entry
-        # Display name (friendly): just the area name
-        self._attr_name = str(_get_option(config_entry, CONF_AREA_NAME, ""))
+        # Display name comes from the `name` property below (so it tolerates
+        # entry renames). `_attr_name` is intentionally not set — the property
+        # would override it anyway.
         self._attr_unique_id = f"custom_area_{config_entry.entry_id}_summary"
         self._attr_should_poll = False
 

--- a/custom_components/custom_areas/sensor.py
+++ b/custom_components/custom_areas/sensor.py
@@ -92,31 +92,38 @@ async def async_setup_entry(
     summary_sensor = AreaSummarySensor(coordinator, config_entry)
     entities: list[SensorEntity] = [summary_sensor]
 
-    # Create measurement sensors conditionally
-    if _get_option(config_entry, CONF_POWER_ENTITY):
-        power_sensor = PowerSensor(coordinator, config_entry)
-        entities.append(power_sensor)
-        summary_sensor.power_sensor = power_sensor
+    # Create measurement sensors conditionally. Each tuple is
+    # (config_key, suffix, name_suffix, default_unit, source_attribute,
+    #  summary_attr) where summary_attr is the AreaSummarySensor attribute
+    # name kept for backward compatibility.
+    measurement_specs = (
+        (CONF_POWER_ENTITY, "power", "Power", UNIT_WATT, None, "power_sensor"),
+        (CONF_ENERGY_ENTITY, "energy", "Energy", UNIT_WATT_HOUR, None, "energy_sensor"),
+        (CONF_TEMP_ENTITY, "temperature", "Temperature", UNIT_CELSIUS, None, "temperature_sensor"),
+        (CONF_HUMIDITY_ENTITY, "humidity", "Humidity", UNIT_HUMIDITY, None, "humidity_sensor"),
+        (
+            CONF_CLIMATE_ENTITY,
+            "climate_target",
+            "Climate Target",
+            UNIT_CELSIUS,
+            "temperature",
+            "climate_target_sensor",
+        ),
+    )
 
-    if _get_option(config_entry, CONF_ENERGY_ENTITY):
-        energy_sensor = EnergySensor(coordinator, config_entry)
-        entities.append(energy_sensor)
-        summary_sensor.energy_sensor = energy_sensor
-
-    if _get_option(config_entry, CONF_TEMP_ENTITY):
-        temperature_sensor = TemperatureSensor(coordinator, config_entry)
-        entities.append(temperature_sensor)
-        summary_sensor.temperature_sensor = temperature_sensor
-
-    if _get_option(config_entry, CONF_HUMIDITY_ENTITY):
-        humidity_sensor = HumiditySensor(coordinator, config_entry)
-        entities.append(humidity_sensor)
-        summary_sensor.humidity_sensor = humidity_sensor
-
-    if _get_option(config_entry, CONF_CLIMATE_ENTITY):
-        climate_target_sensor = ClimateTargetSensor(coordinator, config_entry)
-        entities.append(climate_target_sensor)
-        summary_sensor.climate_target_sensor = climate_target_sensor
+    for config_key, suffix, name_suffix, default_unit, source_attribute, summary_attr in measurement_specs:
+        if _get_option(config_entry, config_key):
+            measurement_sensor = AreaMeasurementSensor(
+                coordinator,
+                config_entry,
+                config_key=config_key,
+                suffix=suffix,
+                name_suffix=name_suffix,
+                default_unit=default_unit,
+                source_attribute=source_attribute,
+            )
+            entities.append(measurement_sensor)
+            setattr(summary_sensor, summary_attr, measurement_sensor)
 
     async_add_entities(entities)
 
@@ -192,12 +199,14 @@ class AreaSummarySensor(SensorEntity):
         self._attr_unique_id = f"custom_area_{config_entry.entry_id}_summary"
         self._attr_should_poll = False
 
-        # References to measurement sensors
-        self.power_sensor: Optional["PowerSensor"] = None
-        self.energy_sensor: Optional["EnergySensor"] = None
-        self.temperature_sensor: Optional["TemperatureSensor"] = None
-        self.humidity_sensor: Optional["HumiditySensor"] = None
-        self.climate_target_sensor: Optional["ClimateTargetSensor"] = None
+        # References to measurement sensors. Attribute names kept (`power_sensor`
+        # etc.) for backward compatibility; the concrete type is now the
+        # parameterized AreaMeasurementSensor.
+        self.power_sensor: Optional["AreaMeasurementSensor"] = None
+        self.energy_sensor: Optional["AreaMeasurementSensor"] = None
+        self.temperature_sensor: Optional["AreaMeasurementSensor"] = None
+        self.humidity_sensor: Optional["AreaMeasurementSensor"] = None
+        self.climate_target_sensor: Optional["AreaMeasurementSensor"] = None
 
         # Register with coordinator
         coordinator.register_sensor(self)
@@ -371,16 +380,55 @@ class AreaSummarySensor(SensorEntity):
         return attrs
 
 
-class PowerSensor(SensorEntity):
-    """Power measurement sensor."""
+class AreaMeasurementSensor(SensorEntity):
+    """Parameterized measurement sensor.
 
-    def __init__(self, coordinator: AreaSensorCoordinator, config_entry: ConfigEntry) -> None:
-        """Initialize the sensor."""
+    Replaces the five near-identical PowerSensor / EnergySensor /
+    TemperatureSensor / HumiditySensor / ClimateTargetSensor classes
+    that differed only by config key, suffix, default unit, and (for
+    ClimateTarget) the fact that the reading is on `state.attributes`
+    rather than `state.state`.
+
+    Behavior is byte-identical to the originals — guarded by
+    test_sensor_characterization.py.
+    """
+
+    def __init__(
+        self,
+        coordinator: "AreaSensorCoordinator",
+        config_entry: ConfigEntry,
+        config_key: str,
+        suffix: str,
+        name_suffix: str,
+        default_unit: str,
+        source_attribute: Optional[str] = None,
+    ) -> None:
+        """Initialize a measurement sensor.
+
+        Args:
+            coordinator: The shared area coordinator (fanned-out updates).
+            config_entry: The HA config entry backing this area.
+            config_key: Key in entry.data/options pointing at the source
+                entity_id (e.g. CONF_POWER_ENTITY).
+            suffix: Used in unique_id and object_id (e.g. "power").
+            name_suffix: Used in display name (e.g. "Power").
+            default_unit: Fallback unit_of_measurement when the source
+                entity doesn't expose one.
+            source_attribute: When None, read the source's `state.state`
+                and parse as float. When set, read
+                `state.attributes[source_attribute]` instead. The latter
+                is the ClimateTarget shape (`source_attribute="temperature"`).
+        """
         self.coordinator = coordinator
         self.config_entry = config_entry
+        self._config_key = config_key
+        self._suffix = suffix
+        self._default_unit = default_unit
+        self._source_attribute = source_attribute
+
         area_name = str(_get_option(config_entry, CONF_AREA_NAME, ""))
-        self._attr_name = f"{area_name} Power"
-        self._attr_unique_id = f"custom_area_{config_entry.entry_id}_power"
+        self._attr_name = f"{area_name} {name_suffix}"
+        self._attr_unique_id = f"custom_area_{config_entry.entry_id}_{suffix}"
         self._attr_should_poll = False
         self._attr_device_info = DeviceInfo(
             identifiers={(DOMAIN, config_entry.entry_id)},
@@ -392,205 +440,47 @@ class PowerSensor(SensorEntity):
 
     @property
     def suggested_object_id(self) -> Optional[str]:
-        """Suggest object_id."""
+        """Suggest object_id (HA slugifies this for the final entity_id)."""
         area_name = str(_get_option(self.config_entry, CONF_AREA_NAME, "")).strip()
-        return f"custom_area_{area_name}_power" if area_name else None
+        return f"custom_area_{area_name}_{self._suffix}" if area_name else None
 
     @property
     def native_value(self) -> Optional[float]:
-        """Return the state of the sensor."""
-        power_entity = _get_option(self.config_entry, CONF_POWER_ENTITY)
-        if power_entity:
-            return get_numeric_state(self.hass, power_entity)
+        """Return the state of the sensor.
+
+        For non-climate sensors (`source_attribute is None`): the parsed
+        float of the source entity's `state.state`.
+        For climate_target (`source_attribute == "temperature"`): the
+        parsed float of `state.attributes["temperature"]`. Returns None
+        when the attribute is falsy, missing, or non-numeric — preserving
+        the pre-refactor behaviour exactly (including the "0.0 → None"
+        edge case that fell out of `if attributes.get(...)`).
+        """
+        entity_id = _get_option(self.config_entry, self._config_key)
+        if not entity_id:
+            return None
+
+        if self._source_attribute is None:
+            return get_numeric_state(self.hass, entity_id)
+
+        state = self.hass.states.get(entity_id)
+        if state and state.attributes.get(self._source_attribute):
+            try:
+                return float(state.attributes[self._source_attribute])
+            except (ValueError, TypeError):
+                pass
         return None
 
     @property
     def native_unit_of_measurement(self) -> Optional[str]:
-        """Return the unit of measurement."""
-        power_entity = _get_option(self.config_entry, CONF_POWER_ENTITY)
-        if power_entity:
-            state = self.hass.states.get(power_entity)
+        """Return the unit of measurement.
+
+        Returns the source entity's `unit_of_measurement` attribute when
+        present; otherwise falls back to `default_unit`.
+        """
+        entity_id = _get_option(self.config_entry, self._config_key)
+        if entity_id:
+            state = self.hass.states.get(entity_id)
             if state and state.attributes.get("unit_of_measurement"):
                 return state.attributes["unit_of_measurement"]  # type: ignore[no-any-return]
-        return UNIT_WATT
-
-
-class EnergySensor(SensorEntity):
-    """Energy measurement sensor."""
-
-    def __init__(self, coordinator: AreaSensorCoordinator, config_entry: ConfigEntry) -> None:
-        """Initialize the sensor."""
-        self.coordinator = coordinator
-        self.config_entry = config_entry
-        area_name = str(_get_option(config_entry, CONF_AREA_NAME, ""))
-        self._attr_name = f"{area_name} Energy"
-        self._attr_unique_id = f"custom_area_{config_entry.entry_id}_energy"
-        self._attr_should_poll = False
-        self._attr_device_info = DeviceInfo(
-            identifiers={(DOMAIN, config_entry.entry_id)},
-            name=f"Area: {_get_option(config_entry, CONF_AREA_NAME)}",
-            manufacturer="Areas Integration",
-            model="Area Sensor",
-        )
-        coordinator.register_sensor(self)
-
-    @property
-    def suggested_object_id(self) -> Optional[str]:
-        """Suggest object_id."""
-        area_name = str(_get_option(self.config_entry, CONF_AREA_NAME, "")).strip()
-        return f"custom_area_{area_name}_energy" if area_name else None
-
-    @property
-    def native_value(self) -> Optional[float]:
-        """Return the state of the sensor."""
-        energy_entity = _get_option(self.config_entry, CONF_ENERGY_ENTITY)
-        if energy_entity:
-            return get_numeric_state(self.hass, energy_entity)
-        return None
-
-    @property
-    def native_unit_of_measurement(self) -> Optional[str]:
-        """Return the unit of measurement."""
-        energy_entity = _get_option(self.config_entry, CONF_ENERGY_ENTITY)
-        if energy_entity:
-            state = self.hass.states.get(energy_entity)
-            if state and state.attributes.get("unit_of_measurement"):
-                return state.attributes["unit_of_measurement"]  # type: ignore[no-any-return]
-        return UNIT_WATT_HOUR
-
-
-class TemperatureSensor(SensorEntity):
-    """Temperature measurement sensor."""
-
-    def __init__(self, coordinator: AreaSensorCoordinator, config_entry: ConfigEntry) -> None:
-        """Initialize the sensor."""
-        self.coordinator = coordinator
-        self.config_entry = config_entry
-        area_name = str(_get_option(config_entry, CONF_AREA_NAME, ""))
-        self._attr_name = f"{area_name} Temperature"
-        self._attr_unique_id = f"custom_area_{config_entry.entry_id}_temperature"
-        self._attr_should_poll = False
-        self._attr_device_info = DeviceInfo(
-            identifiers={(DOMAIN, config_entry.entry_id)},
-            name=f"Area: {_get_option(config_entry, CONF_AREA_NAME)}",
-            manufacturer="Areas Integration",
-            model="Area Sensor",
-        )
-        coordinator.register_sensor(self)
-
-    @property
-    def suggested_object_id(self) -> Optional[str]:
-        """Suggest object_id."""
-        area_name = str(_get_option(self.config_entry, CONF_AREA_NAME, "")).strip()
-        return f"custom_area_{area_name}_temperature" if area_name else None
-
-    @property
-    def native_value(self) -> Optional[float]:
-        """Return the state of the sensor."""
-        temp_entity = _get_option(self.config_entry, CONF_TEMP_ENTITY)
-        if temp_entity:
-            return get_numeric_state(self.hass, temp_entity)
-        return None
-
-    @property
-    def native_unit_of_measurement(self) -> Optional[str]:
-        """Return the unit of measurement."""
-        temp_entity = _get_option(self.config_entry, CONF_TEMP_ENTITY)
-        if temp_entity:
-            state = self.hass.states.get(temp_entity)
-            if state and state.attributes.get("unit_of_measurement"):
-                return state.attributes["unit_of_measurement"]  # type: ignore[no-any-return]
-        return UNIT_CELSIUS
-
-
-class HumiditySensor(SensorEntity):
-    """Humidity measurement sensor."""
-
-    def __init__(self, coordinator: AreaSensorCoordinator, config_entry: ConfigEntry) -> None:
-        """Initialize the sensor."""
-        self.coordinator = coordinator
-        self.config_entry = config_entry
-        area_name = str(_get_option(config_entry, CONF_AREA_NAME, ""))
-        self._attr_name = f"{area_name} Humidity"
-        self._attr_unique_id = f"custom_area_{config_entry.entry_id}_humidity"
-        self._attr_should_poll = False
-        self._attr_device_info = DeviceInfo(
-            identifiers={(DOMAIN, config_entry.entry_id)},
-            name=f"Area: {_get_option(config_entry, CONF_AREA_NAME)}",
-            manufacturer="Areas Integration",
-            model="Area Sensor",
-        )
-        coordinator.register_sensor(self)
-
-    @property
-    def suggested_object_id(self) -> Optional[str]:
-        """Suggest object_id."""
-        area_name = str(_get_option(self.config_entry, CONF_AREA_NAME, "")).strip()
-        return f"custom_area_{area_name}_humidity" if area_name else None
-
-    @property
-    def native_value(self) -> Optional[float]:
-        """Return the state of the sensor."""
-        humidity_entity = _get_option(self.config_entry, CONF_HUMIDITY_ENTITY)
-        if humidity_entity:
-            return get_numeric_state(self.hass, humidity_entity)
-        return None
-
-    @property
-    def native_unit_of_measurement(self) -> Optional[str]:
-        """Return the unit of measurement."""
-        humidity_entity = _get_option(self.config_entry, CONF_HUMIDITY_ENTITY)
-        if humidity_entity:
-            state = self.hass.states.get(humidity_entity)
-            if state and state.attributes.get("unit_of_measurement"):
-                return state.attributes["unit_of_measurement"]  # type: ignore[no-any-return]
-        return UNIT_HUMIDITY
-
-
-class ClimateTargetSensor(SensorEntity):
-    """Climate target temperature sensor."""
-
-    def __init__(self, coordinator: AreaSensorCoordinator, config_entry: ConfigEntry) -> None:
-        """Initialize the sensor."""
-        self.coordinator = coordinator
-        self.config_entry = config_entry
-        area_name = str(_get_option(config_entry, CONF_AREA_NAME, ""))
-        self._attr_name = f"{area_name} Climate Target"
-        self._attr_unique_id = f"custom_area_{config_entry.entry_id}_climate_target"
-        self._attr_should_poll = False
-        self._attr_device_info = DeviceInfo(
-            identifiers={(DOMAIN, config_entry.entry_id)},
-            name=f"Area: {_get_option(config_entry, CONF_AREA_NAME)}",
-            manufacturer="Areas Integration",
-            model="Area Sensor",
-        )
-        coordinator.register_sensor(self)
-
-    @property
-    def suggested_object_id(self) -> Optional[str]:
-        """Suggest object_id."""
-        area_name = str(_get_option(self.config_entry, CONF_AREA_NAME, "")).strip()
-        return f"custom_area_{area_name}_climate_target" if area_name else None
-
-    @property
-    def native_value(self) -> Optional[float]:
-        """Return the state of the sensor."""
-        climate_entity = _get_option(self.config_entry, CONF_CLIMATE_ENTITY)
-        if climate_entity:
-            climate_state = self.hass.states.get(climate_entity)
-            if climate_state and climate_state.attributes.get("temperature"):
-                try:
-                    return float(climate_state.attributes["temperature"])
-                except (ValueError, TypeError):
-                    pass
-        return None
-
-    @property
-    def native_unit_of_measurement(self) -> Optional[str]:
-        """Return the unit of measurement."""
-        climate_entity = _get_option(self.config_entry, CONF_CLIMATE_ENTITY)
-        if climate_entity:
-            state = self.hass.states.get(climate_entity)
-            if state and state.attributes.get("unit_of_measurement"):
-                return state.attributes["unit_of_measurement"]  # type: ignore[no-any-return]
-        return UNIT_CELSIUS
+        return self._default_unit

--- a/custom_components/custom_areas/sensor.py
+++ b/custom_components/custom_areas/sensor.py
@@ -300,29 +300,20 @@ class AreaSummarySensor(SensorEntity):
         """Return the state attributes."""
         attrs: Dict[str, Any] = {}
 
-        # Cache state lookups for performance
-        cached_states = {}
-
-        def get_cached_state(entity_id: str):
-            """Get state with caching to avoid multiple lookups."""
-            if entity_id not in cached_states:
-                cached_states[entity_id] = self.hass.states.get(entity_id)
-            return cached_states[entity_id]
-
         # Binary sensor attributes (motion, window, climate mode)
         motion_entity = _get_option(self.config_entry, CONF_MOTION_ENTITY)
         if motion_entity:
-            motion_state = get_cached_state(motion_entity)
+            motion_state = self.hass.states.get(motion_entity)
             attrs["occupied"] = motion_state.state == STATE_ON if motion_state else False
 
         window_entity = _get_option(self.config_entry, CONF_WINDOW_ENTITY)
         if window_entity:
-            window_state = get_cached_state(window_entity)
+            window_state = self.hass.states.get(window_entity)
             attrs["window_open"] = window_state.state == STATE_ON if window_state else False
 
         climate_entity = _get_option(self.config_entry, CONF_CLIMATE_ENTITY)
         if climate_entity:
-            climate_state = get_cached_state(climate_entity)
+            climate_state = self.hass.states.get(climate_entity)
             if climate_state:
                 attrs["climate_mode"] = climate_state.state
 

--- a/custom_components/custom_areas/sensor.py
+++ b/custom_components/custom_areas/sensor.py
@@ -174,7 +174,7 @@ class AreaSensorCoordinator:
         """Handle state change events."""
         # Update all registered sensors
         for sensor in self._sensors:
-            sensor.async_schedule_update_ha_state()  # pyright: ignore[reportUnusedCoroutine]
+            sensor.async_schedule_update_ha_state()
         return
 
     def register_sensor(self, sensor: SensorEntity) -> None:

--- a/custom_components/custom_areas/sensor.py
+++ b/custom_components/custom_areas/sensor.py
@@ -69,6 +69,18 @@ def get_numeric_state(hass: HomeAssistant, entity_id: str) -> Optional[float]:
     return None
 
 
+def _get_option(entry: ConfigEntry, key: str, default: Any = None) -> Any:
+    """Read a config value with options-take-precedence-over-data semantics.
+
+    `entry.options` is populated by the options flow when an existing entry
+    is reconfigured. Original entries have `entry.options == {}`, so they
+    transparently keep reading from `entry.data` — no migration needed.
+    """
+    if key in entry.options:
+        return entry.options[key]
+    return entry.data.get(key, default)
+
+
 async def async_setup_entry(
     hass: HomeAssistant,
     config_entry: ConfigEntry,
@@ -81,27 +93,27 @@ async def async_setup_entry(
     entities: list[SensorEntity] = [summary_sensor]
 
     # Create measurement sensors conditionally
-    if config_entry.data.get(CONF_POWER_ENTITY):
+    if _get_option(config_entry, CONF_POWER_ENTITY):
         power_sensor = PowerSensor(coordinator, config_entry)
         entities.append(power_sensor)
         summary_sensor.power_sensor = power_sensor
 
-    if config_entry.data.get(CONF_ENERGY_ENTITY):
+    if _get_option(config_entry, CONF_ENERGY_ENTITY):
         energy_sensor = EnergySensor(coordinator, config_entry)
         entities.append(energy_sensor)
         summary_sensor.energy_sensor = energy_sensor
 
-    if config_entry.data.get(CONF_TEMP_ENTITY):
+    if _get_option(config_entry, CONF_TEMP_ENTITY):
         temperature_sensor = TemperatureSensor(coordinator, config_entry)
         entities.append(temperature_sensor)
         summary_sensor.temperature_sensor = temperature_sensor
 
-    if config_entry.data.get(CONF_HUMIDITY_ENTITY):
+    if _get_option(config_entry, CONF_HUMIDITY_ENTITY):
         humidity_sensor = HumiditySensor(coordinator, config_entry)
         entities.append(humidity_sensor)
         summary_sensor.humidity_sensor = humidity_sensor
 
-    if config_entry.data.get(CONF_CLIMATE_ENTITY):
+    if _get_option(config_entry, CONF_CLIMATE_ENTITY):
         climate_target_sensor = ClimateTargetSensor(coordinator, config_entry)
         entities.append(climate_target_sensor)
         summary_sensor.climate_target_sensor = climate_target_sensor
@@ -134,7 +146,7 @@ class AreaSensorCoordinator:
             CONF_WINDOW_ENTITY,
             CONF_CLIMATE_ENTITY,
         ]:
-            entity_id = self.config_entry.data.get(key)
+            entity_id = _get_option(self.config_entry, key)
             if entity_id:
                 entities_to_track.append(entity_id)
                 _LOGGER.debug("Will track entity: %s", entity_id)
@@ -176,7 +188,7 @@ class AreaSummarySensor(SensorEntity):
         self.coordinator = coordinator
         self.config_entry = config_entry
         # Display name (friendly): just the area name
-        self._attr_name = str(config_entry.data.get(CONF_AREA_NAME, ""))
+        self._attr_name = str(_get_option(config_entry, CONF_AREA_NAME, ""))
         self._attr_unique_id = f"custom_area_{config_entry.entry_id}_summary"
         self._attr_should_poll = False
 
@@ -193,7 +205,7 @@ class AreaSummarySensor(SensorEntity):
         # Set up device info
         self._attr_device_info = DeviceInfo(
             identifiers={(DOMAIN, config_entry.entry_id)},
-            name=f"Area: {config_entry.data[CONF_AREA_NAME]}",
+            name=f"Area: {_get_option(config_entry, CONF_AREA_NAME)}",
             manufacturer="Areas Integration",
             model="Area Sensor",
         )
@@ -201,7 +213,7 @@ class AreaSummarySensor(SensorEntity):
     @property
     def name(self) -> str:
         """Return the name of the sensor (display name without area_ prefix)."""
-        area_name = self.config_entry.data.get(CONF_AREA_NAME, "")
+        area_name = _get_option(self.config_entry, CONF_AREA_NAME, "")
         return str(area_name) if area_name else ""
 
     @property
@@ -210,24 +222,22 @@ class AreaSummarySensor(SensorEntity):
 
         Home Assistant will slugify this into the final object_id.
         """
-        area_name = str(self.config_entry.data.get(CONF_AREA_NAME, "")).strip()
+        area_name = str(_get_option(self.config_entry, CONF_AREA_NAME, "")).strip()
         return f"custom_area_{area_name}" if area_name else None
 
     @property
     def native_value(self) -> str:
         """Return the state of the sensor."""
-        data = self.config_entry.data
-
         # Check motion first
-        motion_entity = data.get(CONF_MOTION_ENTITY)
+        motion_entity = _get_option(self.config_entry, CONF_MOTION_ENTITY)
         if motion_entity:
             motion_state = self.hass.states.get(motion_entity)
             if motion_state and motion_state.state == STATE_ON:
                 return STATE_ACTIVE
 
         # Check power threshold
-        power_entity = data.get(CONF_POWER_ENTITY)
-        active_threshold = data.get(CONF_ACTIVE_THRESHOLD, DEFAULT_ACTIVE_THRESHOLD)
+        power_entity = _get_option(self.config_entry, CONF_POWER_ENTITY)
+        active_threshold = _get_option(self.config_entry, CONF_ACTIVE_THRESHOLD, DEFAULT_ACTIVE_THRESHOLD)
         if power_entity:
             power_state = self.hass.states.get(power_entity)
             if power_state:
@@ -240,13 +250,13 @@ class AreaSummarySensor(SensorEntity):
 
         # Check if any core entities exist
         core_entities = [
-            data.get(CONF_POWER_ENTITY),
-            data.get(CONF_ENERGY_ENTITY),
-            data.get(CONF_TEMP_ENTITY),
-            data.get(CONF_HUMIDITY_ENTITY),
-            data.get(CONF_MOTION_ENTITY),
-            data.get(CONF_WINDOW_ENTITY),
-            data.get(CONF_CLIMATE_ENTITY),
+            _get_option(self.config_entry, CONF_POWER_ENTITY),
+            _get_option(self.config_entry, CONF_ENERGY_ENTITY),
+            _get_option(self.config_entry, CONF_TEMP_ENTITY),
+            _get_option(self.config_entry, CONF_HUMIDITY_ENTITY),
+            _get_option(self.config_entry, CONF_MOTION_ENTITY),
+            _get_option(self.config_entry, CONF_WINDOW_ENTITY),
+            _get_option(self.config_entry, CONF_CLIMATE_ENTITY),
         ]
 
         if any(entity for entity in core_entities if entity):
@@ -257,31 +267,28 @@ class AreaSummarySensor(SensorEntity):
     @property
     def icon(self) -> str:
         """Return the icon."""
-        data = self.config_entry.data
-
         # Check window first
-        window_entity = data.get(CONF_WINDOW_ENTITY)
+        window_entity = _get_option(self.config_entry, CONF_WINDOW_ENTITY)
         if window_entity:
             window_state = self.hass.states.get(window_entity)
             if window_state and window_state.state == STATE_ON:
                 return ICON_WINDOW_OPEN
 
         # Check motion
-        motion_entity = data.get(CONF_MOTION_ENTITY)
+        motion_entity = _get_option(self.config_entry, CONF_MOTION_ENTITY)
         if motion_entity:
             motion_state = self.hass.states.get(motion_entity)
             if motion_state and motion_state.state == STATE_ON:
                 return ICON_MOTION
 
         # Return configured icon or default
-        icon_value = data.get(CONF_ICON, DEFAULT_ICON)
+        icon_value = _get_option(self.config_entry, CONF_ICON, DEFAULT_ICON)
         return str(icon_value) if icon_value is not None else DEFAULT_ICON
 
     @property
     def extra_state_attributes(self) -> Dict[str, Any]:
         """Return the state attributes."""
         attrs: Dict[str, Any] = {}
-        data = self.config_entry.data
 
         # Cache state lookups for performance
         cached_states = {}
@@ -293,17 +300,17 @@ class AreaSummarySensor(SensorEntity):
             return cached_states[entity_id]
 
         # Binary sensor attributes (motion, window, climate mode)
-        motion_entity = data.get(CONF_MOTION_ENTITY)
+        motion_entity = _get_option(self.config_entry, CONF_MOTION_ENTITY)
         if motion_entity:
             motion_state = get_cached_state(motion_entity)
             attrs["occupied"] = motion_state.state == STATE_ON if motion_state else False
 
-        window_entity = data.get(CONF_WINDOW_ENTITY)
+        window_entity = _get_option(self.config_entry, CONF_WINDOW_ENTITY)
         if window_entity:
             window_state = get_cached_state(window_entity)
             attrs["window_open"] = window_state.state == STATE_ON if window_state else False
 
-        climate_entity = data.get(CONF_CLIMATE_ENTITY)
+        climate_entity = _get_option(self.config_entry, CONF_CLIMATE_ENTITY)
         if climate_entity:
             climate_state = get_cached_state(climate_entity)
             if climate_state:
@@ -313,7 +320,7 @@ class AreaSummarySensor(SensorEntity):
         # and stringified-with-unit form per the documented contract (README.md,
         # docs/api.md). Pair each numeric/string emission so the contract is
         # grep-able from a single block.
-        power_entity = data.get(CONF_POWER_ENTITY)
+        power_entity = _get_option(self.config_entry, CONF_POWER_ENTITY)
         if power_entity:
             power_value = get_numeric_state(self.hass, power_entity)
             if power_value is not None:
@@ -322,7 +329,7 @@ class AreaSummarySensor(SensorEntity):
                 attrs["power_w"] = power_value
                 attrs["power"] = f"{power_value} {unit}"
 
-        energy_entity = data.get(CONF_ENERGY_ENTITY)
+        energy_entity = _get_option(self.config_entry, CONF_ENERGY_ENTITY)
         if energy_entity:
             energy_value = get_numeric_state(self.hass, energy_entity)
             if energy_value is not None:
@@ -331,7 +338,7 @@ class AreaSummarySensor(SensorEntity):
                 attrs["energy_wh"] = energy_value
                 attrs["energy"] = f"{energy_value} {unit}"
 
-        temp_entity = data.get(CONF_TEMP_ENTITY)
+        temp_entity = _get_option(self.config_entry, CONF_TEMP_ENTITY)
         if temp_entity:
             temp_value = get_numeric_state(self.hass, temp_entity)
             if temp_value is not None:
@@ -340,7 +347,7 @@ class AreaSummarySensor(SensorEntity):
                 attrs["temperature_c"] = temp_value
                 attrs["temperature"] = f"{temp_value} {unit}"
 
-        humidity_entity = data.get(CONF_HUMIDITY_ENTITY)
+        humidity_entity = _get_option(self.config_entry, CONF_HUMIDITY_ENTITY)
         if humidity_entity:
             humidity_value = get_numeric_state(self.hass, humidity_entity)
             if humidity_value is not None:
@@ -349,7 +356,7 @@ class AreaSummarySensor(SensorEntity):
                 attrs["humidity_pct"] = humidity_value
                 attrs["humidity"] = f"{humidity_value} {unit}"
 
-        climate_entity = data.get(CONF_CLIMATE_ENTITY)
+        climate_entity = _get_option(self.config_entry, CONF_CLIMATE_ENTITY)
         if climate_entity:
             climate_state = self.hass.states.get(climate_entity)
             if climate_state and climate_state.attributes.get("temperature"):
@@ -371,13 +378,13 @@ class PowerSensor(SensorEntity):
         """Initialize the sensor."""
         self.coordinator = coordinator
         self.config_entry = config_entry
-        area_name = str(config_entry.data.get(CONF_AREA_NAME, ""))
+        area_name = str(_get_option(config_entry, CONF_AREA_NAME, ""))
         self._attr_name = f"{area_name} Power"
         self._attr_unique_id = f"custom_area_{config_entry.entry_id}_power"
         self._attr_should_poll = False
         self._attr_device_info = DeviceInfo(
             identifiers={(DOMAIN, config_entry.entry_id)},
-            name=f"Area: {config_entry.data[CONF_AREA_NAME]}",
+            name=f"Area: {_get_option(config_entry, CONF_AREA_NAME)}",
             manufacturer="Areas Integration",
             model="Area Sensor",
         )
@@ -386,13 +393,13 @@ class PowerSensor(SensorEntity):
     @property
     def suggested_object_id(self) -> Optional[str]:
         """Suggest object_id."""
-        area_name = str(self.config_entry.data.get(CONF_AREA_NAME, "")).strip()
+        area_name = str(_get_option(self.config_entry, CONF_AREA_NAME, "")).strip()
         return f"custom_area_{area_name}_power" if area_name else None
 
     @property
     def native_value(self) -> Optional[float]:
         """Return the state of the sensor."""
-        power_entity = self.config_entry.data.get(CONF_POWER_ENTITY)
+        power_entity = _get_option(self.config_entry, CONF_POWER_ENTITY)
         if power_entity:
             return get_numeric_state(self.hass, power_entity)
         return None
@@ -400,7 +407,7 @@ class PowerSensor(SensorEntity):
     @property
     def native_unit_of_measurement(self) -> Optional[str]:
         """Return the unit of measurement."""
-        power_entity = self.config_entry.data.get(CONF_POWER_ENTITY)
+        power_entity = _get_option(self.config_entry, CONF_POWER_ENTITY)
         if power_entity:
             state = self.hass.states.get(power_entity)
             if state and state.attributes.get("unit_of_measurement"):
@@ -415,13 +422,13 @@ class EnergySensor(SensorEntity):
         """Initialize the sensor."""
         self.coordinator = coordinator
         self.config_entry = config_entry
-        area_name = str(config_entry.data.get(CONF_AREA_NAME, ""))
+        area_name = str(_get_option(config_entry, CONF_AREA_NAME, ""))
         self._attr_name = f"{area_name} Energy"
         self._attr_unique_id = f"custom_area_{config_entry.entry_id}_energy"
         self._attr_should_poll = False
         self._attr_device_info = DeviceInfo(
             identifiers={(DOMAIN, config_entry.entry_id)},
-            name=f"Area: {config_entry.data[CONF_AREA_NAME]}",
+            name=f"Area: {_get_option(config_entry, CONF_AREA_NAME)}",
             manufacturer="Areas Integration",
             model="Area Sensor",
         )
@@ -430,13 +437,13 @@ class EnergySensor(SensorEntity):
     @property
     def suggested_object_id(self) -> Optional[str]:
         """Suggest object_id."""
-        area_name = str(self.config_entry.data.get(CONF_AREA_NAME, "")).strip()
+        area_name = str(_get_option(self.config_entry, CONF_AREA_NAME, "")).strip()
         return f"custom_area_{area_name}_energy" if area_name else None
 
     @property
     def native_value(self) -> Optional[float]:
         """Return the state of the sensor."""
-        energy_entity = self.config_entry.data.get(CONF_ENERGY_ENTITY)
+        energy_entity = _get_option(self.config_entry, CONF_ENERGY_ENTITY)
         if energy_entity:
             return get_numeric_state(self.hass, energy_entity)
         return None
@@ -444,7 +451,7 @@ class EnergySensor(SensorEntity):
     @property
     def native_unit_of_measurement(self) -> Optional[str]:
         """Return the unit of measurement."""
-        energy_entity = self.config_entry.data.get(CONF_ENERGY_ENTITY)
+        energy_entity = _get_option(self.config_entry, CONF_ENERGY_ENTITY)
         if energy_entity:
             state = self.hass.states.get(energy_entity)
             if state and state.attributes.get("unit_of_measurement"):
@@ -459,13 +466,13 @@ class TemperatureSensor(SensorEntity):
         """Initialize the sensor."""
         self.coordinator = coordinator
         self.config_entry = config_entry
-        area_name = str(config_entry.data.get(CONF_AREA_NAME, ""))
+        area_name = str(_get_option(config_entry, CONF_AREA_NAME, ""))
         self._attr_name = f"{area_name} Temperature"
         self._attr_unique_id = f"custom_area_{config_entry.entry_id}_temperature"
         self._attr_should_poll = False
         self._attr_device_info = DeviceInfo(
             identifiers={(DOMAIN, config_entry.entry_id)},
-            name=f"Area: {config_entry.data[CONF_AREA_NAME]}",
+            name=f"Area: {_get_option(config_entry, CONF_AREA_NAME)}",
             manufacturer="Areas Integration",
             model="Area Sensor",
         )
@@ -474,13 +481,13 @@ class TemperatureSensor(SensorEntity):
     @property
     def suggested_object_id(self) -> Optional[str]:
         """Suggest object_id."""
-        area_name = str(self.config_entry.data.get(CONF_AREA_NAME, "")).strip()
+        area_name = str(_get_option(self.config_entry, CONF_AREA_NAME, "")).strip()
         return f"custom_area_{area_name}_temperature" if area_name else None
 
     @property
     def native_value(self) -> Optional[float]:
         """Return the state of the sensor."""
-        temp_entity = self.config_entry.data.get(CONF_TEMP_ENTITY)
+        temp_entity = _get_option(self.config_entry, CONF_TEMP_ENTITY)
         if temp_entity:
             return get_numeric_state(self.hass, temp_entity)
         return None
@@ -488,7 +495,7 @@ class TemperatureSensor(SensorEntity):
     @property
     def native_unit_of_measurement(self) -> Optional[str]:
         """Return the unit of measurement."""
-        temp_entity = self.config_entry.data.get(CONF_TEMP_ENTITY)
+        temp_entity = _get_option(self.config_entry, CONF_TEMP_ENTITY)
         if temp_entity:
             state = self.hass.states.get(temp_entity)
             if state and state.attributes.get("unit_of_measurement"):
@@ -503,13 +510,13 @@ class HumiditySensor(SensorEntity):
         """Initialize the sensor."""
         self.coordinator = coordinator
         self.config_entry = config_entry
-        area_name = str(config_entry.data.get(CONF_AREA_NAME, ""))
+        area_name = str(_get_option(config_entry, CONF_AREA_NAME, ""))
         self._attr_name = f"{area_name} Humidity"
         self._attr_unique_id = f"custom_area_{config_entry.entry_id}_humidity"
         self._attr_should_poll = False
         self._attr_device_info = DeviceInfo(
             identifiers={(DOMAIN, config_entry.entry_id)},
-            name=f"Area: {config_entry.data[CONF_AREA_NAME]}",
+            name=f"Area: {_get_option(config_entry, CONF_AREA_NAME)}",
             manufacturer="Areas Integration",
             model="Area Sensor",
         )
@@ -518,13 +525,13 @@ class HumiditySensor(SensorEntity):
     @property
     def suggested_object_id(self) -> Optional[str]:
         """Suggest object_id."""
-        area_name = str(self.config_entry.data.get(CONF_AREA_NAME, "")).strip()
+        area_name = str(_get_option(self.config_entry, CONF_AREA_NAME, "")).strip()
         return f"custom_area_{area_name}_humidity" if area_name else None
 
     @property
     def native_value(self) -> Optional[float]:
         """Return the state of the sensor."""
-        humidity_entity = self.config_entry.data.get(CONF_HUMIDITY_ENTITY)
+        humidity_entity = _get_option(self.config_entry, CONF_HUMIDITY_ENTITY)
         if humidity_entity:
             return get_numeric_state(self.hass, humidity_entity)
         return None
@@ -532,7 +539,7 @@ class HumiditySensor(SensorEntity):
     @property
     def native_unit_of_measurement(self) -> Optional[str]:
         """Return the unit of measurement."""
-        humidity_entity = self.config_entry.data.get(CONF_HUMIDITY_ENTITY)
+        humidity_entity = _get_option(self.config_entry, CONF_HUMIDITY_ENTITY)
         if humidity_entity:
             state = self.hass.states.get(humidity_entity)
             if state and state.attributes.get("unit_of_measurement"):
@@ -547,13 +554,13 @@ class ClimateTargetSensor(SensorEntity):
         """Initialize the sensor."""
         self.coordinator = coordinator
         self.config_entry = config_entry
-        area_name = str(config_entry.data.get(CONF_AREA_NAME, ""))
+        area_name = str(_get_option(config_entry, CONF_AREA_NAME, ""))
         self._attr_name = f"{area_name} Climate Target"
         self._attr_unique_id = f"custom_area_{config_entry.entry_id}_climate_target"
         self._attr_should_poll = False
         self._attr_device_info = DeviceInfo(
             identifiers={(DOMAIN, config_entry.entry_id)},
-            name=f"Area: {config_entry.data[CONF_AREA_NAME]}",
+            name=f"Area: {_get_option(config_entry, CONF_AREA_NAME)}",
             manufacturer="Areas Integration",
             model="Area Sensor",
         )
@@ -562,13 +569,13 @@ class ClimateTargetSensor(SensorEntity):
     @property
     def suggested_object_id(self) -> Optional[str]:
         """Suggest object_id."""
-        area_name = str(self.config_entry.data.get(CONF_AREA_NAME, "")).strip()
+        area_name = str(_get_option(self.config_entry, CONF_AREA_NAME, "")).strip()
         return f"custom_area_{area_name}_climate_target" if area_name else None
 
     @property
     def native_value(self) -> Optional[float]:
         """Return the state of the sensor."""
-        climate_entity = self.config_entry.data.get(CONF_CLIMATE_ENTITY)
+        climate_entity = _get_option(self.config_entry, CONF_CLIMATE_ENTITY)
         if climate_entity:
             climate_state = self.hass.states.get(climate_entity)
             if climate_state and climate_state.attributes.get("temperature"):
@@ -581,7 +588,7 @@ class ClimateTargetSensor(SensorEntity):
     @property
     def native_unit_of_measurement(self) -> Optional[str]:
         """Return the unit of measurement."""
-        climate_entity = self.config_entry.data.get(CONF_CLIMATE_ENTITY)
+        climate_entity = _get_option(self.config_entry, CONF_CLIMATE_ENTITY)
         if climate_entity:
             state = self.hass.states.get(climate_entity)
             if state and state.attributes.get("unit_of_measurement"):

--- a/custom_components/custom_areas/sensor.py
+++ b/custom_components/custom_areas/sensor.py
@@ -39,11 +39,6 @@ from .const import (
     STATE_ACTIVE,
 )
 
-UNIT_CELSIUS: str = UnitOfTemperature.CELSIUS
-UNIT_HUMIDITY: str = PERCENTAGE
-UNIT_WATT: str = UnitOfPower.WATT
-UNIT_WATT_HOUR: str = UnitOfEnergy.WATT_HOUR
-
 _LOGGER = logging.getLogger(__name__)
 
 
@@ -98,15 +93,15 @@ async def async_setup_entry(
     #  summary_attr) where summary_attr is the AreaSummarySensor attribute
     # name kept for backward compatibility.
     measurement_specs = (
-        (CONF_POWER_ENTITY, "power", "Power", UNIT_WATT, None, "power_sensor"),
-        (CONF_ENERGY_ENTITY, "energy", "Energy", UNIT_WATT_HOUR, None, "energy_sensor"),
-        (CONF_TEMP_ENTITY, "temperature", "Temperature", UNIT_CELSIUS, None, "temperature_sensor"),
-        (CONF_HUMIDITY_ENTITY, "humidity", "Humidity", UNIT_HUMIDITY, None, "humidity_sensor"),
+        (CONF_POWER_ENTITY, "power", "Power", UnitOfPower.WATT, None, "power_sensor"),
+        (CONF_ENERGY_ENTITY, "energy", "Energy", UnitOfEnergy.WATT_HOUR, None, "energy_sensor"),
+        (CONF_TEMP_ENTITY, "temperature", "Temperature", UnitOfTemperature.CELSIUS, None, "temperature_sensor"),
+        (CONF_HUMIDITY_ENTITY, "humidity", "Humidity", PERCENTAGE, None, "humidity_sensor"),
         (
             CONF_CLIMATE_ENTITY,
             "climate_target",
             "Climate Target",
-            UNIT_CELSIUS,
+            UnitOfTemperature.CELSIUS,
             "temperature",
             "climate_target_sensor",
         ),
@@ -331,7 +326,7 @@ class AreaSummarySensor(SensorEntity):
             power_value = get_numeric_state(self.hass, power_entity)
             if power_value is not None:
                 power_state = self.hass.states.get(power_entity)
-                unit = power_state.attributes.get("unit_of_measurement") if power_state else UNIT_WATT
+                unit = power_state.attributes.get("unit_of_measurement") if power_state else UnitOfPower.WATT
                 attrs["power_w"] = power_value
                 attrs["power"] = f"{power_value} {unit}"
 
@@ -340,7 +335,7 @@ class AreaSummarySensor(SensorEntity):
             energy_value = get_numeric_state(self.hass, energy_entity)
             if energy_value is not None:
                 energy_state = self.hass.states.get(energy_entity)
-                unit = energy_state.attributes.get("unit_of_measurement") if energy_state else UNIT_WATT_HOUR
+                unit = energy_state.attributes.get("unit_of_measurement") if energy_state else UnitOfEnergy.WATT_HOUR
                 attrs["energy_wh"] = energy_value
                 attrs["energy"] = f"{energy_value} {unit}"
 
@@ -349,7 +344,7 @@ class AreaSummarySensor(SensorEntity):
             temp_value = get_numeric_state(self.hass, temp_entity)
             if temp_value is not None:
                 temp_state = self.hass.states.get(temp_entity)
-                unit = temp_state.attributes.get("unit_of_measurement") if temp_state else UNIT_CELSIUS
+                unit = temp_state.attributes.get("unit_of_measurement") if temp_state else UnitOfTemperature.CELSIUS
                 attrs["temperature_c"] = temp_value
                 attrs["temperature"] = f"{temp_value} {unit}"
 
@@ -358,7 +353,7 @@ class AreaSummarySensor(SensorEntity):
             humidity_value = get_numeric_state(self.hass, humidity_entity)
             if humidity_value is not None:
                 humidity_state = self.hass.states.get(humidity_entity)
-                unit = humidity_state.attributes.get("unit_of_measurement") if humidity_state else UNIT_HUMIDITY
+                unit = humidity_state.attributes.get("unit_of_measurement") if humidity_state else PERCENTAGE
                 attrs["humidity_pct"] = humidity_value
                 attrs["humidity"] = f"{humidity_value} {unit}"
 
@@ -368,7 +363,7 @@ class AreaSummarySensor(SensorEntity):
             if climate_state and climate_state.attributes.get("temperature"):
                 try:
                     target_value = float(climate_state.attributes["temperature"])
-                    unit = climate_state.attributes.get("unit_of_measurement") or UNIT_CELSIUS
+                    unit = climate_state.attributes.get("unit_of_measurement") or UnitOfTemperature.CELSIUS
                     attrs["climate_target_c"] = target_value
                     attrs["climate_target"] = f"{target_value} {unit}"
                 except (ValueError, TypeError):

--- a/custom_components/custom_areas/sensor.py
+++ b/custom_components/custom_areas/sensor.py
@@ -1,8 +1,10 @@
 """Sensor platform for Custom Areas Integration."""
 
+from __future__ import annotations
+
 import logging
 from collections.abc import Callable
-from typing import Any
+from typing import TYPE_CHECKING, Any
 
 from homeassistant.components.sensor import SensorEntity
 from homeassistant.config_entries import ConfigEntry
@@ -19,6 +21,9 @@ from homeassistant.core import Event, HomeAssistant, callback
 from homeassistant.helpers.device_registry import DeviceInfo
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from homeassistant.helpers.event import async_track_state_change_event
+
+if TYPE_CHECKING:
+    from homeassistant.helpers.event import EventStateChangedData
 
 from .const import (
     CONF_ACTIVE_THRESHOLD,
@@ -166,7 +171,7 @@ class AreaSensorCoordinator:
             _LOGGER.debug("Successfully registered state change listener")
 
     @callback
-    def _handle_state_change(self, _: Event) -> None:
+    def _handle_state_change(self, _: Event[EventStateChangedData]) -> None:
         """Handle state change events."""
         # Update all registered sensors
         for sensor in self._sensors:

--- a/custom_components/custom_areas/sensor.py
+++ b/custom_components/custom_areas/sensor.py
@@ -17,7 +17,7 @@ from homeassistant.const import (
 from homeassistant.core import Event, HomeAssistant, callback
 from homeassistant.helpers.device_registry import DeviceInfo
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
-from homeassistant.helpers.event import EventStateChangedData, async_track_state_change_event
+from homeassistant.helpers.event import async_track_state_change_event
 
 from .const import (
     CONF_ACTIVE_THRESHOLD,
@@ -151,7 +151,7 @@ class AreaSensorCoordinator:
             _LOGGER.debug("Successfully registered state change listener")
 
     @callback
-    def _handle_state_change(self, event: Event[EventStateChangedData]) -> None:
+    def _handle_state_change(self, _event: Event) -> None:
         """Handle state change events."""
         # Update all registered sensors
         for sensor in self._sensors:

--- a/custom_components/custom_areas/sensor.py
+++ b/custom_components/custom_areas/sensor.py
@@ -181,8 +181,12 @@ class AreaSensorCoordinator:
         """Register a sensor."""
         self._sensors.append(sensor)
 
-    def async_shutdown(self):
-        """Clean up listeners."""
+    def shutdown(self):
+        """Clean up listeners.
+
+        Synchronous despite the surrounding HA `async_*` convention — this
+        method only calls listener-removal callbacks, no awaitables.
+        """
         for listener in self._listeners:
             listener()
 

--- a/custom_components/custom_areas/tests/test_sensor.py
+++ b/custom_components/custom_areas/tests/test_sensor.py
@@ -28,11 +28,7 @@ from custom_components.custom_areas.const import (
     CONF_WINDOW_ENTITY,
     STATE_ACTIVE,
 )
-from custom_components.custom_areas.sensor import (
-    AreaMeasurementSensor,
-    AreaSensorCoordinator,
-    AreaSummarySensor,
-)
+from custom_components.custom_areas.sensor import AreaMeasurementSensor, AreaSensorCoordinator, AreaSummarySensor
 
 
 @pytest.fixture

--- a/custom_components/custom_areas/tests/test_sensor.py
+++ b/custom_components/custom_areas/tests/test_sensor.py
@@ -32,7 +32,12 @@ from custom_components.custom_areas.sensor import (
 
 @pytest.fixture
 def mock_config_entry():
-    """Mock config entry."""
+    """Mock config entry.
+
+    `entry.options` is set to `{}` so `sensor._get_option`'s options-take-
+    precedence helper walks through to `entry.data`. Older HA versions
+    don't expose `options` on `ConfigEntry`'s class-level spec.
+    """
     entry = MagicMock(spec=ConfigEntry)
     entry.entry_id = "test_entry_id"
     entry.data = {
@@ -46,6 +51,7 @@ def mock_config_entry():
         CONF_CLIMATE_ENTITY: "climate.thermostat",
         CONF_ACTIVE_THRESHOLD: 50.0,
     }
+    entry.options = {}
     return entry
 
 

--- a/custom_components/custom_areas/tests/test_sensor.py
+++ b/custom_components/custom_areas/tests/test_sensor.py
@@ -4,7 +4,16 @@ from unittest.mock import MagicMock
 
 import pytest
 from homeassistant.config_entries import ConfigEntry
-from homeassistant.const import STATE_IDLE, STATE_OFF, STATE_ON, STATE_UNKNOWN
+from homeassistant.const import (
+    PERCENTAGE,
+    STATE_IDLE,
+    STATE_OFF,
+    STATE_ON,
+    STATE_UNKNOWN,
+    UnitOfEnergy,
+    UnitOfPower,
+    UnitOfTemperature,
+)
 from homeassistant.core import HomeAssistant
 
 from custom_components.custom_areas.const import (
@@ -20,13 +29,9 @@ from custom_components.custom_areas.const import (
     STATE_ACTIVE,
 )
 from custom_components.custom_areas.sensor import (
+    AreaMeasurementSensor,
     AreaSensorCoordinator,
     AreaSummarySensor,
-    ClimateTargetSensor,
-    EnergySensor,
-    HumiditySensor,
-    PowerSensor,
-    TemperatureSensor,
 )
 
 
@@ -167,27 +172,67 @@ def test_area_summary_sensor_attributes(mock_coordinator, mock_config_entry, moc
     sensor.hass = mock_hass
 
     # Create and assign measurement sensors
-    power_sensor = PowerSensor(mock_coordinator, mock_config_entry)
+    power_sensor = AreaMeasurementSensor(
+        mock_coordinator,
+        mock_config_entry,
+        config_key=CONF_POWER_ENTITY,
+        suffix="power",
+        name_suffix="Power",
+        default_unit=UnitOfPower.WATT,
+        source_attribute=None,
+    )
     power_sensor.hass = mock_hass
     setattr(power_sensor, "_attr_unit_of_measurement", "W")
     sensor.power_sensor = power_sensor
 
-    energy_sensor = EnergySensor(mock_coordinator, mock_config_entry)
+    energy_sensor = AreaMeasurementSensor(
+        mock_coordinator,
+        mock_config_entry,
+        config_key=CONF_ENERGY_ENTITY,
+        suffix="energy",
+        name_suffix="Energy",
+        default_unit=UnitOfEnergy.WATT_HOUR,
+        source_attribute=None,
+    )
     energy_sensor.hass = mock_hass
     setattr(energy_sensor, "_attr_unit_of_measurement", "Wh")
     sensor.energy_sensor = energy_sensor
 
-    temperature_sensor = TemperatureSensor(mock_coordinator, mock_config_entry)
+    temperature_sensor = AreaMeasurementSensor(
+        mock_coordinator,
+        mock_config_entry,
+        config_key=CONF_TEMP_ENTITY,
+        suffix="temperature",
+        name_suffix="Temperature",
+        default_unit=UnitOfTemperature.CELSIUS,
+        source_attribute=None,
+    )
     temperature_sensor.hass = mock_hass
     setattr(temperature_sensor, "_attr_unit_of_measurement", "°C")
     sensor.temperature_sensor = temperature_sensor
 
-    humidity_sensor = HumiditySensor(mock_coordinator, mock_config_entry)
+    humidity_sensor = AreaMeasurementSensor(
+        mock_coordinator,
+        mock_config_entry,
+        config_key=CONF_HUMIDITY_ENTITY,
+        suffix="humidity",
+        name_suffix="Humidity",
+        default_unit=PERCENTAGE,
+        source_attribute=None,
+    )
     humidity_sensor.hass = mock_hass
     setattr(humidity_sensor, "_attr_unit_of_measurement", "%")
     sensor.humidity_sensor = humidity_sensor
 
-    climate_target_sensor = ClimateTargetSensor(mock_coordinator, mock_config_entry)
+    climate_target_sensor = AreaMeasurementSensor(
+        mock_coordinator,
+        mock_config_entry,
+        config_key=CONF_CLIMATE_ENTITY,
+        suffix="climate_target",
+        name_suffix="Climate Target",
+        default_unit=UnitOfTemperature.CELSIUS,
+        source_attribute="temperature",
+    )
     climate_target_sensor.hass = mock_hass
     setattr(climate_target_sensor, "_attr_unit_of_measurement", "°C")
     sensor.climate_target_sensor = climate_target_sensor

--- a/custom_components/custom_areas/tests/test_sensor_characterization.py
+++ b/custom_components/custom_areas/tests/test_sensor_characterization.py
@@ -1,0 +1,335 @@
+"""Characterization tests for the measurement sensor classes.
+
+These tests pin the public surface (unique_id, name, suggested_object_id,
+device_info, native_value, native_unit_of_measurement) of the five
+measurement sensor classes so the M1 refactor (collapsing the five
+near-identical classes into a single parameterized `AreaMeasurementSensor`)
+can be proven byte-identical.
+
+If any case here regresses after the M1 refactor, revert M1 — do NOT patch
+this file to match the new behaviour. That would defeat the gate.
+
+`EXPECTED_SENSOR_SURFACE` at the top is the explicit, grep-able contract.
+"""
+
+from typing import Any
+from unittest.mock import MagicMock
+
+import pytest
+from homeassistant.config_entries import ConfigEntry
+from homeassistant.const import (
+    PERCENTAGE,
+    UnitOfEnergy,
+    UnitOfPower,
+    UnitOfTemperature,
+)
+from homeassistant.core import HomeAssistant
+
+from custom_components.custom_areas.const import (
+    CONF_AREA_NAME,
+    CONF_CLIMATE_ENTITY,
+    CONF_ENERGY_ENTITY,
+    CONF_HUMIDITY_ENTITY,
+    CONF_POWER_ENTITY,
+    CONF_TEMP_ENTITY,
+    DOMAIN,
+)
+from custom_components.custom_areas.sensor import (
+    AreaSensorCoordinator,
+    ClimateTargetSensor,
+    EnergySensor,
+    HumiditySensor,
+    PowerSensor,
+    TemperatureSensor,
+)
+
+EXPECTED_SENSOR_SURFACE: dict[str, dict[str, Any]] = {
+    "power": {
+        "class": PowerSensor,
+        "config_key": CONF_POWER_ENTITY,
+        "entity_id": "sensor.power",
+        "unique_id_suffix": "power",
+        "name_suffix": "Power",
+        "default_unit": UnitOfPower.WATT,
+        "source_attribute": None,
+    },
+    "energy": {
+        "class": EnergySensor,
+        "config_key": CONF_ENERGY_ENTITY,
+        "entity_id": "sensor.energy",
+        "unique_id_suffix": "energy",
+        "name_suffix": "Energy",
+        "default_unit": UnitOfEnergy.WATT_HOUR,
+        "source_attribute": None,
+    },
+    "temperature": {
+        "class": TemperatureSensor,
+        "config_key": CONF_TEMP_ENTITY,
+        "entity_id": "sensor.temperature",
+        "unique_id_suffix": "temperature",
+        "name_suffix": "Temperature",
+        "default_unit": UnitOfTemperature.CELSIUS,
+        "source_attribute": None,
+    },
+    "humidity": {
+        "class": HumiditySensor,
+        "config_key": CONF_HUMIDITY_ENTITY,
+        "entity_id": "sensor.humidity",
+        "unique_id_suffix": "humidity",
+        "name_suffix": "Humidity",
+        "default_unit": PERCENTAGE,
+        "source_attribute": None,
+    },
+    "climate_target": {
+        "class": ClimateTargetSensor,
+        "config_key": CONF_CLIMATE_ENTITY,
+        "entity_id": "climate.thermostat",
+        "unique_id_suffix": "climate_target",
+        "name_suffix": "Climate Target",
+        "default_unit": UnitOfTemperature.CELSIUS,
+        "source_attribute": "temperature",
+    },
+}
+
+
+# Parametrize tests across all 5 sensor types so any post-M1 divergence
+# shows up as a single failing case in the test report.
+SENSOR_IDS = list(EXPECTED_SENSOR_SURFACE.keys())
+
+
+@pytest.fixture
+def mock_config_entry():
+    """Mock config entry covering all five measurement sources."""
+    entry = MagicMock(spec=ConfigEntry)
+    entry.entry_id = "test_entry_id"
+    entry.data = {
+        CONF_AREA_NAME: "Test Area",
+        CONF_POWER_ENTITY: "sensor.power",
+        CONF_ENERGY_ENTITY: "sensor.energy",
+        CONF_TEMP_ENTITY: "sensor.temperature",
+        CONF_HUMIDITY_ENTITY: "sensor.humidity",
+        CONF_CLIMATE_ENTITY: "climate.thermostat",
+    }
+    return entry
+
+
+@pytest.fixture
+def mock_hass():
+    """Mock Home Assistant with a controllable states registry."""
+    hass = MagicMock(spec=HomeAssistant)
+    hass.states = MagicMock()
+    return hass
+
+
+@pytest.fixture
+def mock_coordinator(mock_hass, mock_config_entry):
+    """Coordinator backed by the mocked hass + config entry."""
+    return AreaSensorCoordinator(mock_hass, mock_config_entry)
+
+
+def _make_sensor(spec: dict[str, Any], mock_coordinator, mock_config_entry, mock_hass):
+    """Instantiate the sensor class for a given spec and wire `hass`."""
+    sensor = spec["class"](mock_coordinator, mock_config_entry)
+    sensor.hass = mock_hass
+    return sensor
+
+
+@pytest.mark.parametrize("sensor_id", SENSOR_IDS)
+def test_unique_id(sensor_id, mock_coordinator, mock_config_entry, mock_hass):
+    """unique_id follows the `custom_area_<entry_id>_<suffix>` pattern."""
+    spec = EXPECTED_SENSOR_SURFACE[sensor_id]
+    sensor = _make_sensor(spec, mock_coordinator, mock_config_entry, mock_hass)
+
+    expected = f"custom_area_test_entry_id_{spec['unique_id_suffix']}"
+    assert sensor.unique_id == expected
+
+
+@pytest.mark.parametrize("sensor_id", SENSOR_IDS)
+def test_attr_name(sensor_id, mock_coordinator, mock_config_entry, mock_hass):
+    """_attr_name follows the `<Area Name> <Name Suffix>` pattern."""
+    spec = EXPECTED_SENSOR_SURFACE[sensor_id]
+    sensor = _make_sensor(spec, mock_coordinator, mock_config_entry, mock_hass)
+
+    expected = f"Test Area {spec['name_suffix']}"
+    assert sensor._attr_name == expected
+
+
+@pytest.mark.parametrize("sensor_id", SENSOR_IDS)
+def test_suggested_object_id(sensor_id, mock_coordinator, mock_config_entry, mock_hass):
+    """suggested_object_id returns `custom_area_<area_name>_<suffix>`.
+
+    The area name is stripped but not slugified by the property itself —
+    Home Assistant slugifies the result when computing the final entity_id.
+    The characterization here captures the property's raw return value.
+    """
+    spec = EXPECTED_SENSOR_SURFACE[sensor_id]
+    sensor = _make_sensor(spec, mock_coordinator, mock_config_entry, mock_hass)
+
+    expected = f"custom_area_Test Area_{spec['unique_id_suffix']}"
+    assert sensor.suggested_object_id == expected
+
+
+@pytest.mark.parametrize("sensor_id", SENSOR_IDS)
+def test_device_info_identifiers(sensor_id, mock_coordinator, mock_config_entry, mock_hass):
+    """device_info["identifiers"] anchors the sensor to the area device."""
+    spec = EXPECTED_SENSOR_SURFACE[sensor_id]
+    sensor = _make_sensor(spec, mock_coordinator, mock_config_entry, mock_hass)
+
+    assert sensor.device_info is not None
+    assert sensor.device_info["identifiers"] == {(DOMAIN, "test_entry_id")}
+
+
+@pytest.mark.parametrize("sensor_id", SENSOR_IDS)
+def test_device_info_name(sensor_id, mock_coordinator, mock_config_entry, mock_hass):
+    """device_info["name"] follows the `Area: <area_name>` pattern."""
+    spec = EXPECTED_SENSOR_SURFACE[sensor_id]
+    sensor = _make_sensor(spec, mock_coordinator, mock_config_entry, mock_hass)
+
+    assert sensor.device_info is not None
+    assert sensor.device_info["name"] == "Area: Test Area"
+
+
+@pytest.mark.parametrize("sensor_id", SENSOR_IDS)
+def test_device_info_manufacturer(sensor_id, mock_coordinator, mock_config_entry, mock_hass):
+    """device_info["manufacturer"] is the constant `Areas Integration`."""
+    spec = EXPECTED_SENSOR_SURFACE[sensor_id]
+    sensor = _make_sensor(spec, mock_coordinator, mock_config_entry, mock_hass)
+
+    assert sensor.device_info is not None
+    assert sensor.device_info["manufacturer"] == "Areas Integration"
+
+
+@pytest.mark.parametrize("sensor_id", SENSOR_IDS)
+def test_device_info_model(sensor_id, mock_coordinator, mock_config_entry, mock_hass):
+    """device_info["model"] is the constant `Area Sensor`."""
+    spec = EXPECTED_SENSOR_SURFACE[sensor_id]
+    sensor = _make_sensor(spec, mock_coordinator, mock_config_entry, mock_hass)
+
+    assert sensor.device_info is not None
+    assert sensor.device_info["model"] == "Area Sensor"
+
+
+@pytest.mark.parametrize("sensor_id", SENSOR_IDS)
+def test_native_unit_uses_source_entity_unit(sensor_id, mock_coordinator, mock_config_entry, mock_hass):
+    """native_unit_of_measurement returns the source entity's unit when set."""
+    spec = EXPECTED_SENSOR_SURFACE[sensor_id]
+    sensor = _make_sensor(spec, mock_coordinator, mock_config_entry, mock_hass)
+
+    # Source entity reports its own unit.
+    source_state = MagicMock()
+    source_state.state = "1.0"
+    source_state.attributes = {"unit_of_measurement": "custom-unit", "temperature": 1.0}
+
+    def mock_get(entity_id):
+        if entity_id == spec["entity_id"]:
+            return source_state
+        return None
+
+    mock_hass.states.get = mock_get
+
+    assert sensor.native_unit_of_measurement == "custom-unit"
+
+
+@pytest.mark.parametrize("sensor_id", SENSOR_IDS)
+def test_native_unit_falls_back_when_attribute_missing(sensor_id, mock_coordinator, mock_config_entry, mock_hass):
+    """Falls back to `default_unit` when source entity has no unit attribute."""
+    spec = EXPECTED_SENSOR_SURFACE[sensor_id]
+    sensor = _make_sensor(spec, mock_coordinator, mock_config_entry, mock_hass)
+
+    source_state = MagicMock()
+    source_state.state = "1.0"
+    source_state.attributes = {"temperature": 1.0}  # no unit_of_measurement
+
+    def mock_get(entity_id):
+        if entity_id == spec["entity_id"]:
+            return source_state
+        return None
+
+    mock_hass.states.get = mock_get
+
+    assert sensor.native_unit_of_measurement == spec["default_unit"]
+
+
+@pytest.mark.parametrize("sensor_id", SENSOR_IDS)
+def test_native_unit_falls_back_when_entity_missing(sensor_id, mock_coordinator, mock_config_entry, mock_hass):
+    """Falls back to `default_unit` when the source entity doesn't exist."""
+    spec = EXPECTED_SENSOR_SURFACE[sensor_id]
+    sensor = _make_sensor(spec, mock_coordinator, mock_config_entry, mock_hass)
+
+    mock_hass.states.get = MagicMock(return_value=None)
+
+    assert sensor.native_unit_of_measurement == spec["default_unit"]
+
+
+@pytest.mark.parametrize("sensor_id", SENSOR_IDS)
+def test_native_value_parses_source(sensor_id, mock_coordinator, mock_config_entry, mock_hass):
+    """native_value returns the parsed float of the source reading.
+
+    For non-climate sensors: parsed `state.state`.
+    For climate_target:     parsed `state.attributes["temperature"]`.
+    """
+    spec = EXPECTED_SENSOR_SURFACE[sensor_id]
+    sensor = _make_sensor(spec, mock_coordinator, mock_config_entry, mock_hass)
+
+    source_state = MagicMock()
+    source_state.state = "25.5"
+    source_state.attributes = {"unit_of_measurement": "X", "temperature": 25.5}
+
+    def mock_get(entity_id):
+        if entity_id == spec["entity_id"]:
+            return source_state
+        return None
+
+    mock_hass.states.get = mock_get
+
+    assert sensor.native_value == 25.5
+
+
+@pytest.mark.parametrize("sensor_id", SENSOR_IDS)
+def test_native_value_none_when_entity_missing(sensor_id, mock_coordinator, mock_config_entry, mock_hass):
+    """native_value is None when the source entity doesn't exist."""
+    spec = EXPECTED_SENSOR_SURFACE[sensor_id]
+    sensor = _make_sensor(spec, mock_coordinator, mock_config_entry, mock_hass)
+
+    mock_hass.states.get = MagicMock(return_value=None)
+
+    assert sensor.native_value is None
+
+
+@pytest.mark.parametrize("sensor_id", ["power", "energy", "temperature", "humidity"])
+def test_native_value_none_for_non_numeric_state(sensor_id, mock_coordinator, mock_config_entry, mock_hass):
+    """native_value is None when the source state isn't a float (non-climate)."""
+    spec = EXPECTED_SENSOR_SURFACE[sensor_id]
+    sensor = _make_sensor(spec, mock_coordinator, mock_config_entry, mock_hass)
+
+    source_state = MagicMock()
+    source_state.state = "not-a-number"
+    source_state.attributes = {}
+
+    def mock_get(entity_id):
+        if entity_id == spec["entity_id"]:
+            return source_state
+        return None
+
+    mock_hass.states.get = mock_get
+
+    assert sensor.native_value is None
+
+
+def test_climate_target_native_value_none_when_temperature_attr_missing(mock_coordinator, mock_config_entry, mock_hass):
+    """ClimateTarget returns None when the `temperature` attribute is absent."""
+    spec = EXPECTED_SENSOR_SURFACE["climate_target"]
+    sensor = _make_sensor(spec, mock_coordinator, mock_config_entry, mock_hass)
+
+    source_state = MagicMock()
+    source_state.state = "heat"
+    source_state.attributes = {}  # no temperature attr
+
+    def mock_get(entity_id):
+        if entity_id == spec["entity_id"]:
+            return source_state
+        return None
+
+    mock_hass.states.get = mock_get
+
+    assert sensor.native_value is None

--- a/custom_components/custom_areas/tests/test_sensor_characterization.py
+++ b/custom_components/custom_areas/tests/test_sensor_characterization.py
@@ -178,11 +178,11 @@ def test_device_info_identifiers(sensor_id, mock_coordinator, mock_config_entry,
     sensor = _make_sensor(spec, mock_coordinator, mock_config_entry, mock_hass)
 
     assert sensor.device_info is not None
-    # DeviceInfo is a TypedDict with optional keys; subscript suppresses are
-    # for pyright since the integration always sets these.
-    assert sensor.device_info["identifiers"] == {
-        (DOMAIN, "test_entry_id")
-    }  # pyright: ignore[reportTypedDictNotRequiredAccess]
+    # DeviceInfo is a TypedDict with optional keys; suppress lives on the
+    # subscript line itself (pyright tracks diagnostics per-line) since the
+    # integration always sets these four fields at construction time.
+    identifiers = sensor.device_info["identifiers"]  # pyright: ignore[reportTypedDictNotRequiredAccess]
+    assert identifiers == {(DOMAIN, "test_entry_id")}
 
 
 @pytest.mark.parametrize("sensor_id", SENSOR_IDS)
@@ -202,9 +202,8 @@ def test_device_info_manufacturer(sensor_id, mock_coordinator, mock_config_entry
     sensor = _make_sensor(spec, mock_coordinator, mock_config_entry, mock_hass)
 
     assert sensor.device_info is not None
-    assert (
-        sensor.device_info["manufacturer"] == "Areas Integration"
-    )  # pyright: ignore[reportTypedDictNotRequiredAccess]
+    manufacturer = sensor.device_info["manufacturer"]  # pyright: ignore[reportTypedDictNotRequiredAccess]
+    assert manufacturer == "Areas Integration"
 
 
 @pytest.mark.parametrize("sensor_id", SENSOR_IDS)

--- a/custom_components/custom_areas/tests/test_sensor_characterization.py
+++ b/custom_components/custom_areas/tests/test_sensor_characterization.py
@@ -99,7 +99,12 @@ SENSOR_IDS = list(EXPECTED_SENSOR_SURFACE.keys())
 
 @pytest.fixture
 def mock_config_entry():
-    """Mock config entry covering all five measurement sources."""
+    """Mock config entry covering all five measurement sources.
+
+    `entry.options` is set to `{}` so the options-take-precedence helper in
+    `sensor._get_option` walks through to `entry.data`. Older HA versions
+    don't expose `options` on `ConfigEntry`'s class-level spec.
+    """
     entry = MagicMock(spec=ConfigEntry)
     entry.entry_id = "test_entry_id"
     entry.data = {
@@ -110,6 +115,7 @@ def mock_config_entry():
         CONF_HUMIDITY_ENTITY: "sensor.humidity",
         CONF_CLIMATE_ENTITY: "climate.thermostat",
     }
+    entry.options = {}
     return entry
 
 

--- a/custom_components/custom_areas/tests/test_sensor_characterization.py
+++ b/custom_components/custom_areas/tests/test_sensor_characterization.py
@@ -183,7 +183,9 @@ def test_device_info_identifiers(sensor_id, mock_coordinator, mock_config_entry,
     sensor = _make_sensor(spec, mock_coordinator, mock_config_entry, mock_hass)
 
     assert sensor.device_info is not None
-    assert sensor.device_info["identifiers"] == {(DOMAIN, "test_entry_id")}
+    # DeviceInfo is a TypedDict with optional keys; subscript suppresses are
+    # for pyright since the integration always sets these.
+    assert sensor.device_info["identifiers"] == {(DOMAIN, "test_entry_id")}  # type: ignore[typeddict-item]
 
 
 @pytest.mark.parametrize("sensor_id", SENSOR_IDS)
@@ -193,7 +195,7 @@ def test_device_info_name(sensor_id, mock_coordinator, mock_config_entry, mock_h
     sensor = _make_sensor(spec, mock_coordinator, mock_config_entry, mock_hass)
 
     assert sensor.device_info is not None
-    assert sensor.device_info["name"] == "Area: Test Area"
+    assert sensor.device_info["name"] == "Area: Test Area"  # type: ignore[typeddict-item]
 
 
 @pytest.mark.parametrize("sensor_id", SENSOR_IDS)
@@ -203,7 +205,7 @@ def test_device_info_manufacturer(sensor_id, mock_coordinator, mock_config_entry
     sensor = _make_sensor(spec, mock_coordinator, mock_config_entry, mock_hass)
 
     assert sensor.device_info is not None
-    assert sensor.device_info["manufacturer"] == "Areas Integration"
+    assert sensor.device_info["manufacturer"] == "Areas Integration"  # type: ignore[typeddict-item]
 
 
 @pytest.mark.parametrize("sensor_id", SENSOR_IDS)
@@ -213,7 +215,7 @@ def test_device_info_model(sensor_id, mock_coordinator, mock_config_entry, mock_
     sensor = _make_sensor(spec, mock_coordinator, mock_config_entry, mock_hass)
 
     assert sensor.device_info is not None
-    assert sensor.device_info["model"] == "Area Sensor"
+    assert sensor.device_info["model"] == "Area Sensor"  # type: ignore[typeddict-item]
 
 
 @pytest.mark.parametrize("sensor_id", SENSOR_IDS)

--- a/custom_components/custom_areas/tests/test_sensor_characterization.py
+++ b/custom_components/custom_areas/tests/test_sensor_characterization.py
@@ -180,7 +180,9 @@ def test_device_info_identifiers(sensor_id, mock_coordinator, mock_config_entry,
     assert sensor.device_info is not None
     # DeviceInfo is a TypedDict with optional keys; subscript suppresses are
     # for pyright since the integration always sets these.
-    assert sensor.device_info["identifiers"] == {(DOMAIN, "test_entry_id")}  # pyright: ignore[reportTypedDictNotRequiredAccess]
+    assert sensor.device_info["identifiers"] == {
+        (DOMAIN, "test_entry_id")
+    }  # pyright: ignore[reportTypedDictNotRequiredAccess]
 
 
 @pytest.mark.parametrize("sensor_id", SENSOR_IDS)
@@ -200,7 +202,9 @@ def test_device_info_manufacturer(sensor_id, mock_coordinator, mock_config_entry
     sensor = _make_sensor(spec, mock_coordinator, mock_config_entry, mock_hass)
 
     assert sensor.device_info is not None
-    assert sensor.device_info["manufacturer"] == "Areas Integration"  # pyright: ignore[reportTypedDictNotRequiredAccess]
+    assert (
+        sensor.device_info["manufacturer"] == "Areas Integration"
+    )  # pyright: ignore[reportTypedDictNotRequiredAccess]
 
 
 @pytest.mark.parametrize("sensor_id", SENSOR_IDS)

--- a/custom_components/custom_areas/tests/test_sensor_characterization.py
+++ b/custom_components/custom_areas/tests/test_sensor_characterization.py
@@ -17,12 +17,7 @@ from unittest.mock import MagicMock
 
 import pytest
 from homeassistant.config_entries import ConfigEntry
-from homeassistant.const import (
-    PERCENTAGE,
-    UnitOfEnergy,
-    UnitOfPower,
-    UnitOfTemperature,
-)
+from homeassistant.const import PERCENTAGE, UnitOfEnergy, UnitOfPower, UnitOfTemperature
 from homeassistant.core import HomeAssistant
 
 from custom_components.custom_areas.const import (
@@ -185,7 +180,7 @@ def test_device_info_identifiers(sensor_id, mock_coordinator, mock_config_entry,
     assert sensor.device_info is not None
     # DeviceInfo is a TypedDict with optional keys; subscript suppresses are
     # for pyright since the integration always sets these.
-    assert sensor.device_info["identifiers"] == {(DOMAIN, "test_entry_id")}  # type: ignore[typeddict-item]
+    assert sensor.device_info["identifiers"] == {(DOMAIN, "test_entry_id")}  # pyright: ignore[reportTypedDictNotRequiredAccess]
 
 
 @pytest.mark.parametrize("sensor_id", SENSOR_IDS)
@@ -195,7 +190,7 @@ def test_device_info_name(sensor_id, mock_coordinator, mock_config_entry, mock_h
     sensor = _make_sensor(spec, mock_coordinator, mock_config_entry, mock_hass)
 
     assert sensor.device_info is not None
-    assert sensor.device_info["name"] == "Area: Test Area"  # type: ignore[typeddict-item]
+    assert sensor.device_info["name"] == "Area: Test Area"  # pyright: ignore[reportTypedDictNotRequiredAccess]
 
 
 @pytest.mark.parametrize("sensor_id", SENSOR_IDS)
@@ -205,7 +200,7 @@ def test_device_info_manufacturer(sensor_id, mock_coordinator, mock_config_entry
     sensor = _make_sensor(spec, mock_coordinator, mock_config_entry, mock_hass)
 
     assert sensor.device_info is not None
-    assert sensor.device_info["manufacturer"] == "Areas Integration"  # type: ignore[typeddict-item]
+    assert sensor.device_info["manufacturer"] == "Areas Integration"  # pyright: ignore[reportTypedDictNotRequiredAccess]
 
 
 @pytest.mark.parametrize("sensor_id", SENSOR_IDS)
@@ -215,7 +210,7 @@ def test_device_info_model(sensor_id, mock_coordinator, mock_config_entry, mock_
     sensor = _make_sensor(spec, mock_coordinator, mock_config_entry, mock_hass)
 
     assert sensor.device_info is not None
-    assert sensor.device_info["model"] == "Area Sensor"  # type: ignore[typeddict-item]
+    assert sensor.device_info["model"] == "Area Sensor"  # pyright: ignore[reportTypedDictNotRequiredAccess]
 
 
 @pytest.mark.parametrize("sensor_id", SENSOR_IDS)

--- a/custom_components/custom_areas/tests/test_sensor_characterization.py
+++ b/custom_components/custom_areas/tests/test_sensor_characterization.py
@@ -34,18 +34,15 @@ from custom_components.custom_areas.const import (
     CONF_TEMP_ENTITY,
     DOMAIN,
 )
-from custom_components.custom_areas.sensor import (
-    AreaSensorCoordinator,
-    ClimateTargetSensor,
-    EnergySensor,
-    HumiditySensor,
-    PowerSensor,
-    TemperatureSensor,
-)
+from custom_components.custom_areas.sensor import AreaMeasurementSensor, AreaSensorCoordinator
 
+# Per-sensor specs. Construction now goes through `AreaMeasurementSensor` for
+# every type — pre-M1 each spec named its dedicated class here (PowerSensor,
+# EnergySensor, ...). The collapse to a single parameterized class is the
+# refactor under test; the *assertions* about output strings, device_info,
+# native_value, and native_unit are unchanged from the pre-M1 snapshot.
 EXPECTED_SENSOR_SURFACE: dict[str, dict[str, Any]] = {
     "power": {
-        "class": PowerSensor,
         "config_key": CONF_POWER_ENTITY,
         "entity_id": "sensor.power",
         "unique_id_suffix": "power",
@@ -54,7 +51,6 @@ EXPECTED_SENSOR_SURFACE: dict[str, dict[str, Any]] = {
         "source_attribute": None,
     },
     "energy": {
-        "class": EnergySensor,
         "config_key": CONF_ENERGY_ENTITY,
         "entity_id": "sensor.energy",
         "unique_id_suffix": "energy",
@@ -63,7 +59,6 @@ EXPECTED_SENSOR_SURFACE: dict[str, dict[str, Any]] = {
         "source_attribute": None,
     },
     "temperature": {
-        "class": TemperatureSensor,
         "config_key": CONF_TEMP_ENTITY,
         "entity_id": "sensor.temperature",
         "unique_id_suffix": "temperature",
@@ -72,7 +67,6 @@ EXPECTED_SENSOR_SURFACE: dict[str, dict[str, Any]] = {
         "source_attribute": None,
     },
     "humidity": {
-        "class": HumiditySensor,
         "config_key": CONF_HUMIDITY_ENTITY,
         "entity_id": "sensor.humidity",
         "unique_id_suffix": "humidity",
@@ -81,7 +75,6 @@ EXPECTED_SENSOR_SURFACE: dict[str, dict[str, Any]] = {
         "source_attribute": None,
     },
     "climate_target": {
-        "class": ClimateTargetSensor,
         "config_key": CONF_CLIMATE_ENTITY,
         "entity_id": "climate.thermostat",
         "unique_id_suffix": "climate_target",
@@ -134,8 +127,16 @@ def mock_coordinator(mock_hass, mock_config_entry):
 
 
 def _make_sensor(spec: dict[str, Any], mock_coordinator, mock_config_entry, mock_hass):
-    """Instantiate the sensor class for a given spec and wire `hass`."""
-    sensor = spec["class"](mock_coordinator, mock_config_entry)
+    """Instantiate AreaMeasurementSensor for a given spec and wire `hass`."""
+    sensor = AreaMeasurementSensor(
+        mock_coordinator,
+        mock_config_entry,
+        config_key=spec["config_key"],
+        suffix=spec["unique_id_suffix"],
+        name_suffix=spec["name_suffix"],
+        default_unit=spec["default_unit"],
+        source_attribute=spec["source_attribute"],
+    )
     sensor.hass = mock_hass
     return sensor
 


### PR DESCRIPTION
## Summary

Largest of the five PRs. Adds the options flow (no more delete-and-recreate to reconfigure an area), collapses the five duplicate measurement-sensor classes into one parameterized class with a byte-identity gate, slugifies unique_ids, and ~10 smaller cleanups.

### High-impact changes

- **H3 — Options flow.** New \`AreasOptionsFlowHandler\` lets users reconfigure an existing area via Settings → Devices & Services → Configure. Wired via \`AreasConfigFlow.async_get_options_flow\`. Existing entries have \`entry.options == {}\` so they keep reading from \`entry.data\` — no migration. New \`_get_option(entry, key, default)\` helper in \`sensor.py\` threads options→data fallback through every \`CONF_*\` read.
- **H5 — Slugified unique_id.** \`Living Room\`, \`living room\`, and \` Living Room \` now collide on one \`unique_id\`. Existing entries' stored unique_ids are not migrated; new entries only.
- **M1 — Sensor-class collapse.** \`PowerSensor\` + \`EnergySensor\` + \`TemperatureSensor\` + \`HumiditySensor\` + \`ClimateTargetSensor\` → one \`AreaMeasurementSensor\` parameterized by \`(config_key, suffix, name_suffix, default_unit, source_attribute)\`. ClimateTarget reads from \`state.attributes["temperature"]\`; others read \`state.state\`. Net: ~116 LOC removed.

### Byte-identity gate (commit \`a41bd3b\` and \`04d20b8\`)

Before the M1 refactor, added a **characterization test** at \`tests/test_sensor_characterization.py\` that captures the public surface of all five original classes: \`unique_id\`, \`_attr_name\`, \`suggested_object_id\`, \`device_info[identifiers/name/manufacturer/model]\`, \`native_unit_of_measurement\` (with source-unit + fallback paths), and \`native_value\` (with None paths for missing entity / non-numeric state / missing climate \`temperature\` attr).

- **Before M1**: 65/65 pass on \`AreaMeasurementSensor\`'s 5 original-class equivalents.
- **After M1**: 65/65 pass on the parameterized class.

If even one had diverged, M1 would have been reverted in-place. None did.

### Smaller items

- **H1** — \`__init__.py:34\` uses \`CONF_AREA_NAME\` constant instead of raw \`'area_name'\` string.
- **M2** — Dead \`_attr_name\` assignment removed from \`AreaSummarySensor.__init__\` (the \`name\` property already overrides it).
- **M3** — Ineffective \`cached_states\` closure in \`extra_state_attributes\` removed (numeric attrs bypassed it anyway).
- **M5** — \`AreaSensorCoordinator.async_shutdown\` → \`shutdown\` (it's sync; the \`async_\` prefix was a naming lie).
- **M6** — Removed bogus \`# pyright: ignore[reportUnusedCoroutine]\` (the target returns None).
- **M7** — Setup-failure logging trimmed from 3 \`_LOGGER.error\` calls + manual \`traceback.format_exc()\` to one \`_LOGGER.warning(..., exc_info=ex)\`. The deliberate \`ConfigEntryNotReady\` re-raise (AGENTS.md/CLAUDE.md) is preserved.
- **L1/L2** — \`AreasConfigFlow._data = {}\` and redundant \`DOMAIN = DOMAIN\` class attribute removed.
- **L3** — Typing modernization in \`sensor.py\`: \`Dict\`/\`Optional\`/\`Callable\` from \`typing\` → built-ins (\`dict\`, \`X | None\`, \`collections.abc.Callable\`).
- **L4** — \`UNIT_*\` module aliases removed; HA constants (\`UnitOfPower.WATT\` etc.) used at call sites directly.
- **L6** — \`vol.Optional(CONF_ACTIVE_THRESHOLD, default=DEFAULT_ACTIVE_THRESHOLD)\` materializes the default at config time.
- Pre-existing pyright errors on \`sensor.py:154\` (Event subscript, unused param) and \`config_flow.py:8\` (ConfigFlowResult import) all fixed.

### Pyright state

Final: **0 errors, 0 warnings, 0 informations** on this branch. Cleaner than master.

### Tail end (fixup commits)

The last six commits are linter-dance to land cleanly under Phase 5's escalated pyright config:
\`e398ea2\` / \`b982e30\` / \`ccc3a02\` / \`a7734f5\` — voluptuous + DeviceInfo TypedDict suppress dance; \`48ea25e\` — dropped unused \`_LOGGER\` from \`config_flow.py\`; \`6071e69\` — renamed unused \`_event\` param to \`_\`. Each is small and individually rollback-safe.

## Test plan

- [ ] CI green (test matrix HA 2024/2025/2026)
- [ ] \`python -m pytest custom_components/custom_areas/tests/test_sensor_characterization.py -v\` — 65/65 pass
- [ ] In an HA dev instance: open Settings → Devices & Services → an existing Custom Area → Configure. Schema renders with current values pre-filled. Save. Entity recomputes with the new values.
- [ ] Try to create two areas with names "Living Room" and "living room" — second is rejected (already_configured)
- [ ] Trigger a setup failure (e.g., point a config to a coordinator that raises): only one log line, includes traceback, ConfigEntryNotReady retry kicks in.

## Stacking note

Branched off \`phase-1-contract-restoration\`. Recommended to land after Phase 1, Phase 5, and Phase 4. **Before merging Phase 2**, so Phase 2's rebase can update \`test_init.py:87\` and \`test_sensor.py:367\` from \`async_shutdown\` → \`shutdown\` (M5's rename).

Generated with [Claude Code](https://claude.com/claude-code)