### PR TITLE
chore: bump dev toolchain to Python 3.14, add HA 2026-latest matrix cell

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,6 +38,13 @@ jobs:
             ha-version: "2026"
             phacc-pin: "pytest-homeassistant-custom-component==0.13.316"
             extra-pins: ""
+          # HA 2026 latest — phacc 0.13.317+ requires Python 3.14 and
+          # HA 2026.3.0+ requires Python 3.14.2. This cell tracks the
+          # moving head of HA against the current stable Python.
+          - python-version: "3.14"
+            ha-version: "2026-latest"
+            phacc-pin: "pytest-homeassistant-custom-component==0.13.333"
+            extra-pins: ""
     name: test (py${{ matrix.python-version }}, HA ${{ matrix.ha-version }})
     steps:
     - uses: actions/checkout@v6
@@ -87,7 +94,7 @@ jobs:
     - name: Set up Python
       uses: actions/setup-python@v6
       with:
-        python-version: "3.13"
+        python-version: "3.14"
 
     - name: Install dependencies
       run: |
@@ -106,7 +113,7 @@ jobs:
     - name: Set up Python
       uses: actions/setup-python@v6
       with:
-        python-version: "3.13"
+        python-version: "3.14"
 
     - name: Install dependencies
       run: |
@@ -176,7 +183,7 @@ jobs:
     - name: Set up Python
       uses: actions/setup-python@v6
       with:
-        python-version: "3.13"
+        python-version: "3.14"
 
     - name: Install dependencies
       run: |

--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -17,7 +17,7 @@ jobs:
     - name: Set up Python
       uses: actions/setup-python@v6
       with:
-        python-version: "3.13"
+        python-version: "3.14"
 
     - name: Install dependencies
       run: |

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -20,7 +20,7 @@ custom_components/custom_areas/   # the integration (all runtime code lives here
 ├── strings.json + translations/  # i18n
 └── tests/test_sensor.py          # pytest-asyncio + MagicMock(spec=HomeAssistant)
 docs/                             # mkdocs site (api, examples, developer, rationale)
-.github/workflows/ci.yml          # 3-cell matrix: HA 2024(py3.12), HA 2025/2026(py3.13)
+.github/workflows/ci.yml          # 4-cell matrix: HA 2024(py3.12), HA 2025/2026(py3.13), HA 2026-latest(py3.14)
 check_all.py, validate.py, run_tests.py, run_mypy.sh   # local dev orchestrators
 ```
 
@@ -51,7 +51,7 @@ check_all.py, validate.py, run_tests.py, run_mypy.sh   # local dev orchestrators
 - **Don't break the 120-col line limit** to match upstream HA's 88.
 - **Don't catch `Exception` then swallow** — `__init__.py` deliberately re-raises as `ConfigEntryNotReady`. Preserve that.
 - **Don't add new dev tooling** — black/isort/flake8/mypy/pyright/ruff already overlap. Pick the one that fires; don't add a 7th.
-- **Don't bump HA min version** without checking the CI matrix (`2024.4.0` is the floor; matrix tests 2024/2025/2026).
+- **Don't bump HA min version** without checking the CI matrix (`2024.4.0` is the floor; matrix tests 2024/2025/2026/2026-latest across py3.12/3.13/3.14). The non-matrix jobs (lint, type-check, validate, pre-commit) install `requirements-dev.txt` directly on py3.14 — its `homeassistant>=2026.5.4` floor gates that.
 
 ## UNIQUE STYLES
 
@@ -72,7 +72,7 @@ black custom_components/custom_areas/            # apply formatting (line-length
 isort custom_components/custom_areas/            # apply import sort
 ```
 
-CI runs `check_all.py` equivalent across the 3-cell HA matrix in `.github/workflows/ci.yml`.
+CI runs `check_all.py` equivalent across the 4-cell HA matrix in `.github/workflows/ci.yml`.
 
 ## NOTES
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -24,7 +24,7 @@ pre-commit run --all-files # same hooks CI runs
 
 Single test: `pytest custom_components/custom_areas/tests/test_sensor.py::TestClass::test_name -v`
 
-CI runs a 3-cell matrix (HA 2024/py3.12, HA 2025/py3.13, HA 2026/py3.13) in `.github/workflows/ci.yml`, each pinning a specific `pytest-homeassistant-custom-component` version. Don't bump the HA floor (`2024.4.0` in `manifest.json`) without updating the matrix.
+CI runs a 4-cell matrix (HA 2024/py3.12, HA 2025/py3.13, HA 2026/py3.13, HA 2026-latest/py3.14) in `.github/workflows/ci.yml`, each pinning a specific `pytest-homeassistant-custom-component` version. The py3.14 cell tracks the moving head of HA (phacc 0.13.317+ and HA 2026.3.0+ require Python 3.14). The non-matrix jobs (lint, type-check, validate, pre-commit) run on py3.14 because `requirements-dev.txt`'s `homeassistant>=2026.5.4` floor needs it. Don't bump the HA floor (`2024.4.0` in `manifest.json`) without updating the matrix.
 
 ## Non-obvious conventions
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,7 +28,7 @@ ensure_newline_before_comments = true
 skip = ["stubs"]
 
 [tool.mypy]
-python_version = "3.13"
+python_version = "3.14"
 warn_return_any = true
 warn_unused_configs = true
 disallow_untyped_defs = false  # Allow untyped defs for HA compatibility

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -2,10 +2,10 @@
 pytest>=7.0.0
 pytest-asyncio>=1.3.0
 pytest-cov>=3.0.0
-pytest-homeassistant-custom-component>=0.13.298,<0.13.317
+pytest-homeassistant-custom-component>=0.13.333
 
 # Home Assistant testing
-homeassistant>=2023.6.0
+homeassistant>=2026.5.4
 voluptuous>=0.13.0
 
 # Code quality


### PR DESCRIPTION
## Summary

Adds a 4th CI matrix cell on Python 3.14 / HA 2026-latest, moves the non-matrix jobs (lint, type-check, validate, pre-commit) to py3.14, and bumps `requirements-dev.txt` floors to `homeassistant>=2026.5.4` and `pytest-homeassistant-custom-component>=0.13.333`. This unblocks Dependabot PRs #30 and #31, which were stuck because both target dependencies require Python ≥3.14 / ≥3.14.2.

## Why

- phacc 0.13.317+ → `Requires-Python >=3.14`
- HA 2026.3.0+ → `Requires-Python >=3.14.2`

The matrix was capped at py3.13, so `pip install -r requirements-dev.txt` failed on PRs that bumped either floor. The existing `py3.13 / HA 2026 / phacc==0.13.316` cell stays as the "last py3.13" boundary — the new cell sits beside it for the moving HA head.

## Changes

### `.github/workflows/ci.yml`
- Add 4th matrix cell: `py3.14 / ha-version=2026-latest / phacc==0.13.333`.
- `validate`, `type-check`, `lint` jobs: setup-python `3.13` → `3.14`.

### `.github/workflows/pre-commit.yml`
- setup-python `3.13` → `3.14`.

### `requirements-dev.txt`
- `homeassistant>=2023.6.0` → `>=2026.5.4`.
- `pytest-homeassistant-custom-component>=0.13.298,<0.13.317` → `>=0.13.333`. The upper cap existed only to keep py3.13 dev installs away from py3.14-gated phacc — no longer needed since the dev floor is now py3.14.

### `AGENTS.md` and `CLAUDE.md`
- "3-cell matrix" → "4-cell matrix"; note that non-matrix jobs are on py3.14 because of the requirements-dev.txt floor.

## Pre-flight already done
- ✅ `actions/setup-python@v6` resolves Python 3.14.2/3/4/5 on `ubuntu-24.04` (latest stable 3.14.5).
- ✅ All dev tools (mypy 2.1.0, pre-commit 4.6.0, black 26.5.1, isort 8.0.1, flake8 7.3.0, ruff 0.15.14, pyright 1.1.409, pytest 9.0.3, pytest-cov 7.1.0, voluptuous 0.16.0, phacc 0.13.333, homeassistant 2026.5.4) ship py3.14-compatible wheels.
- Not run locally: `python check_all.py` — toolchain now requires py3.14.2+ which isn't installed locally. CI is the verification.

## Test plan

- [ ] All 4 matrix cells pass `test`
- [ ] `lint`, `type-check`, `validate`, `pre-commit`, `hassfest`, `hacs-validation` pass on py3.14
- [ ] `codecov/patch` and `codecov/project` resolve (currently gated to `ha-version == '2026'`, the existing py3.13 cell — unchanged)
- [ ] After merge, `@dependabot rebase` #30 and #31 — both should turn green or auto-close as obsolete

## Not in scope
- `manifest.json` HA floor (`2024.4.0`) stays — runtime support for older HA is independent of dev tooling.
- CHANGELOG entry — convention has been to add CI/dev-tooling entries at release time, not per-PR.
- `.github/dependabot.yml` ignore list — no longer needed if this PR works; revisit only if the matrix bump is reverted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)