### PR TITLE
docs: add community-health files and issue/PR templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,70 @@
+name: 🐛 Bug Report
+description: Report a problem with the Custom Areas integration
+labels: ["bug"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for taking the time to report a bug! Please fill out the form below.
+        For questions or general help, use [Discussions](https://github.com/DefinitelyADev/custom-areas-integration/discussions) instead.
+  - type: checkboxes
+    attributes:
+      label: Pre-flight checklist
+      options:
+        - label: I'm running the latest released version of the integration.
+          required: true
+        - label: I searched existing issues and didn't find a duplicate.
+          required: true
+  - type: input
+    id: integration-version
+    attributes:
+      label: Integration version
+      placeholder: "e.g. 1.2.0"
+    validations:
+      required: true
+  - type: input
+    id: ha-version
+    attributes:
+      label: Home Assistant version
+      placeholder: "e.g. 2026.5.4"
+    validations:
+      required: true
+  - type: textarea
+    id: what-happened
+    attributes:
+      label: What happened?
+      description: A clear description of the bug and its impact.
+    validations:
+      required: true
+  - type: textarea
+    id: expected
+    attributes:
+      label: Expected behaviour
+      description: What did you expect to happen instead?
+    validations:
+      required: true
+  - type: textarea
+    id: steps
+    attributes:
+      label: Steps to reproduce
+      placeholder: |
+        1. Configure an area with '...'
+        2. Change entity '...'
+        3. See '...'
+    validations:
+      required: true
+  - type: textarea
+    id: config
+    attributes:
+      label: Area configuration
+      description: Which entity types did you configure for the affected area (power, energy, temperature, motion, etc.)?
+    validations:
+      required: false
+  - type: textarea
+    id: logs
+    attributes:
+      label: Relevant logs
+      description: Paste any related Home Assistant logs. Remove personal data (tokens, exact locations) before posting.
+      render: shell
+    validations:
+      required: false

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,8 @@
+blank_issues_enabled: false
+contact_links:
+  - name: 💬 Questions & Discussions
+    url: https://github.com/DefinitelyADev/custom-areas-integration/discussions
+    about: Ask questions, share setups, and discuss ideas here.
+  - name: 🔒 Report a security vulnerability
+    url: https://github.com/DefinitelyADev/custom-areas-integration/security/advisories/new
+    about: Please report security issues privately, not as public issues.

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,43 @@
+name: 💡 Feature Request
+description: Suggest an idea or improvement for the Custom Areas integration
+labels: ["enhancement"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for the idea! Please describe what you'd like and why.
+        For open-ended discussion, [Discussions](https://github.com/DefinitelyADev/custom-areas-integration/discussions) is a better fit.
+  - type: checkboxes
+    attributes:
+      label: Pre-flight checklist
+      options:
+        - label: I searched existing issues and didn't find a duplicate request.
+          required: true
+  - type: textarea
+    id: problem
+    attributes:
+      label: What problem does this solve?
+      description: A clear description of the problem or limitation you're hitting.
+    validations:
+      required: true
+  - type: textarea
+    id: solution
+    attributes:
+      label: Proposed solution
+      description: What would you like the integration to do?
+    validations:
+      required: true
+  - type: textarea
+    id: alternatives
+    attributes:
+      label: Alternatives considered
+      description: Any workarounds or other approaches you've thought about.
+    validations:
+      required: false
+  - type: textarea
+    id: context
+    attributes:
+      label: Additional context
+      description: Anything else that helps — example setups, mockups, related entities.
+    validations:
+      required: false

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,23 @@
+<!-- Thanks for contributing! Please fill out the sections below. -->
+
+## Description
+
+<!-- What does this PR change, and why? -->
+
+## Type of change
+
+- [ ] 🐛 Bug fix
+- [ ] ✨ New feature
+- [ ] 📝 Documentation
+- [ ] ♻️ Refactor / chore
+
+## Checklist
+
+- [ ] `python check_all.py` passes locally
+- [ ] Tests added or updated where it makes sense
+- [ ] Docs updated if needed (README / `docs/` / `strings.json` + `translations/en.json`)
+- [ ] Conventions followed (config keys in `const.py`, event-driven, line length 120)
+
+## Related issues
+
+<!-- e.g. Closes #123 -->

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,83 @@
+# Contributor Covenant Code of Conduct
+
+## Our Pledge
+
+We as members, contributors, and leaders pledge to make participation in our community a harassment-free experience for everyone, regardless of age, body size, visible or invisible disability, ethnicity, sex characteristics, gender identity and expression, level of experience, education, socio-economic status, nationality, personal appearance, race, caste, color, religion, or sexual identity and orientation.
+
+We pledge to act and interact in ways that contribute to an open, welcoming, diverse, inclusive, and healthy community.
+
+## Our Standards
+
+Examples of behavior that contributes to a positive environment for our community include:
+
+* Demonstrating empathy and kindness toward other people
+* Being respectful of differing opinions, viewpoints, and experiences
+* Giving and gracefully accepting constructive feedback
+* Accepting responsibility and apologizing to those affected by our mistakes, and learning from the experience
+* Focusing on what is best not just for us as individuals, but for the overall community
+
+Examples of unacceptable behavior include:
+
+* The use of sexualized language or imagery, and sexual attention or advances of any kind
+* Trolling, insulting or derogatory comments, and personal or political attacks
+* Public or private harassment
+* Publishing others' private information, such as a physical or email address, without their explicit permission
+* Other conduct which could reasonably be considered inappropriate in a professional setting
+
+## Enforcement Responsibilities
+
+Community leaders are responsible for clarifying and enforcing our standards of acceptable behavior and will take appropriate and fair corrective action in response to any behavior that they deem inappropriate, threatening, offensive, or harmful.
+
+Community leaders have the right and responsibility to remove, edit, or reject comments, commits, code, wiki edits, issues, and other contributions that are not aligned to this Code of Conduct, and will communicate reasons for moderation decisions when appropriate.
+
+## Scope
+
+This Code of Conduct applies within all community spaces, and also applies when an individual is officially representing the community in public spaces. Examples of representing our community include using an official e-mail address, posting via an official social media account, or acting as an appointed representative at an online or offline event.
+
+## Enforcement
+
+Instances of abusive, harassing, or otherwise unacceptable behavior may be reported to the community leaders responsible for enforcement at a private report through the repository [Security Advisories](https://github.com/DefinitelyADev/custom-areas-integration/security/advisories/new) page. All complaints will be reviewed and investigated promptly and fairly.
+
+All community leaders are obligated to respect the privacy and security of the reporter of any incident.
+
+## Enforcement Guidelines
+
+Community leaders will follow these Community Impact Guidelines in determining the consequences for any action they deem in violation of this Code of Conduct:
+
+### 1. Correction
+
+**Community Impact**: Use of inappropriate language or other behavior deemed unprofessional or unwelcome in the community.
+
+**Consequence**: A private, written warning from community leaders, providing clarity around the nature of the violation and an explanation of why the behavior was inappropriate. A public apology may be requested.
+
+### 2. Warning
+
+**Community Impact**: A violation through a single incident or series of actions.
+
+**Consequence**: A warning with consequences for continued behavior. No interaction with the people involved, including unsolicited interaction with those enforcing the Code of Conduct, for a specified period of time. This includes avoiding interactions in community spaces as well as external channels like social media. Violating these terms may lead to a temporary or permanent ban.
+
+### 3. Temporary Ban
+
+**Community Impact**: A serious violation of community standards, including sustained inappropriate behavior.
+
+**Consequence**: A temporary ban from any sort of interaction or public communication with the community for a specified period of time. No public or private interaction with the people involved, including unsolicited interaction with those enforcing the Code of Conduct, is allowed during this period. Violating these terms may lead to a permanent ban.
+
+### 4. Permanent Ban
+
+**Community Impact**: Demonstrating a pattern of violation of community standards, including sustained inappropriate behavior, harassment of an individual, or aggression toward or disparagement of classes of individuals.
+
+**Consequence**: A permanent ban from any sort of public interaction within the community.
+
+## Attribution
+
+This Code of Conduct is adapted from the [Contributor Covenant][homepage], version 2.1, available at [https://www.contributor-covenant.org/version/2/1/code_of_conduct.html][v2.1].
+
+Community Impact Guidelines were inspired by [Mozilla's code of conduct enforcement ladder][Mozilla CoC].
+
+For answers to common questions about this code of conduct, see the FAQ at [https://www.contributor-covenant.org/faq][FAQ]. Translations are available at [https://www.contributor-covenant.org/translations][translations].
+
+[homepage]: https://www.contributor-covenant.org
+[v2.1]: https://www.contributor-covenant.org/version/2/1/code_of_conduct.html
+[Mozilla CoC]: https://github.com/mozilla/diversity
+[FAQ]: https://www.contributor-covenant.org/faq
+[translations]: https://www.contributor-covenant.org/translations

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,78 @@
+# Contributing
+
+Thanks for your interest in improving **Custom Areas Integration**! Contributions
+of all sizes are welcome — bug reports, docs, tests, and code.
+
+This project is "vibe coded" (see the [README](README.md)), which mostly means:
+keep it useful, keep it tested, and don't be precious about it. PRs that make it
+better are always welcome.
+
+## Ways to contribute
+
+- 🐛 **Report a bug** — open an [issue](https://github.com/DefinitelyADev/custom-areas-integration/issues/new/choose)
+- 💡 **Request a feature** — open an [issue](https://github.com/DefinitelyADev/custom-areas-integration/issues/new/choose)
+- 🙋 **Ask a question** — use [Discussions](https://github.com/DefinitelyADev/custom-areas-integration/discussions)
+- 🔧 **Send a fix or feature** — open a pull request (see below)
+
+## Development setup
+
+Requires **Python 3.13+** (the project targets Home Assistant ≥ 2024.4.0).
+
+```bash
+git clone https://github.com/DefinitelyADev/custom-areas-integration.git
+cd custom-areas-integration
+python -m venv .venv && source .venv/bin/activate
+pip install -r requirements-dev.txt
+pre-commit install
+```
+
+## Before you open a PR
+
+Run the full local gate — it mirrors what CI checks:
+
+```bash
+python check_all.py
+```
+
+Or run the pieces individually:
+
+| Command                        | What it does                              |
+| ------------------------------ | ----------------------------------------- |
+| `python run_tests.py`          | pytest with branch coverage               |
+| `python validate.py`           | manifest / translations / structure checks |
+| `./run_mypy.sh`                | mypy (run from the project root)          |
+| `pre-commit run --all-files`   | the same hooks CI runs                     |
+
+Run a single test:
+
+```bash
+pytest custom_components/custom_areas/tests/test_sensor.py::TestClass::test_name -v
+```
+
+## Conventions
+
+- **Line length is 120** everywhere (black, isort, flake8) — not 88.
+- **Event-driven only** — subscribe with `async_track_state_change_event`; no
+  polling, no `SCAN_INTERVAL`.
+- **UI configuration only** — config flow, never YAML.
+- Config keys live in `const.py` (the single source of truth) — never inline
+  string keys elsewhere.
+- When adding a config option, touch files in this order:
+  `const.py` → `config_flow.py` → `sensor.py` → `strings.json` +
+  `translations/en.json` → `tests/test_sensor.py`.
+- Tests live **inside** the package, in `custom_components/custom_areas/tests/`.
+
+See the [Developer Guide](docs/developer.md) for architecture details.
+
+## Pull request process
+
+1. Fork the repo (or branch, if you have access) and create a topic branch.
+2. Make your change, with tests and docs where it makes sense.
+3. Make sure `python check_all.py` passes locally.
+4. Open a PR against `master`. All status checks must pass before it can merge.
+5. PRs are merged with **squash** or **rebase** (no merge commits), and the
+   branch is kept up to date with `master` first.
+
+By contributing, you agree that your contributions will be licensed under the
+[Apache License 2.0](LICENSE), and that you'll follow the
+[Code of Conduct](CODE_OF_CONDUCT.md).

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,52 @@
+# Security Policy
+
+## Supported Versions
+
+`custom_areas` is a Home Assistant custom integration distributed through HACS.
+Security fixes are applied to the latest released version only — please update to
+the newest release before reporting an issue.
+
+| Version | Supported          |
+| ------- | ------------------ |
+| 1.2.x   | :white_check_mark: |
+| < 1.2   | :x:                |
+
+## Reporting a Vulnerability
+
+**Please do not report security vulnerabilities through public GitHub issues,
+discussions, or pull requests.**
+
+Instead, report them privately through GitHub's built-in vulnerability reporting:
+
+➡️ **[Report a vulnerability](https://github.com/DefinitelyADev/custom-areas-integration/security/advisories/new)**
+
+(You can also reach this from the repository's **Security** tab → **Advisories**
+→ **Report a vulnerability**.)
+
+Please include:
+
+- A description of the vulnerability and its impact
+- Steps to reproduce, or a proof of concept
+- The integration version and Home Assistant version affected
+- Any relevant logs, with personal data (entity IDs, tokens, locations) removed
+
+## What to Expect
+
+- I'll acknowledge your report as soon as I reasonably can.
+- I'll confirm the issue and determine the affected versions.
+- I'll work on a fix and release it, crediting you if you'd like.
+
+This is a community project maintained in spare time, so response times are
+best-effort — thank you for your patience and for helping keep it safe.
+
+## Scope
+
+This integration reads existing Home Assistant entity states and exposes
+composite sensors. It has no cloud component, stores no credentials, and runs
+entirely within your Home Assistant instance. The reports most relevant to this
+project include:
+
+- Unsafe handling of untrusted entity / attribute data
+- Code that could crash or hang Home Assistant
+- Exposure of sensitive data through sensor attributes or logs
+- Vulnerabilities in the integration's dependencies


### PR DESCRIPTION
## Description

Adds the standard community-health files this public repo was missing:

- **`SECURITY.md`** — security policy pointing to GitHub private vulnerability reporting (now enabled on the repo)
- **`CONTRIBUTING.md`** — dev setup, the local gate (`check_all.py` and friends), conventions, and PR process
- **`CODE_OF_CONDUCT.md`** — Contributor Covenant 2.1
- **`.github/ISSUE_TEMPLATE/`** — bug-report + feature-request issue forms, plus `config.yml` routing questions to Discussions and security reports to the advisory form
- **`.github/PULL_REQUEST_TEMPLATE.md`**

## Notes

- The CoC enforcement contact currently points to the repo **Security Advisories** page — swap in a dedicated email if you'd prefer.
- This is the first PR through the new `master` ruleset (PR required, 12 status checks, branch up-to-date before merge, squash/rebase only).

## Checklist

- [x] `pre-commit` passes on the new files
- [x] Docs / templates only — no code changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)
